### PR TITLE
Allow validating item versions to be configurable

### DIFF
--- a/catalog_validation/validation.py
+++ b/catalog_validation/validation.py
@@ -38,7 +38,7 @@ def validate_train(train_path):
     verrors.check()
 
 
-def validate_catalog_item(catalog_item_path, schema):
+def validate_catalog_item(catalog_item_path, schema, validate_versions=True):
     # We should ensure that each catalog item has at least 1 version available
     # Also that we have item.yaml present
     verrors = ValidationErrors()
@@ -63,7 +63,7 @@ def validate_catalog_item(catalog_item_path, schema):
 
         validate_key_value_types(item_config, (('categories', list),), verrors, f'{schema}.item_config')
 
-    for version_path in versions:
+    for version_path in (versions if validate_versions else []):
         try:
             validate_catalog_item_version(version_path, f'{schema}.versions.{os.path.basename(version_path)}')
         except ValidationErrors as e:

--- a/debian/rules
+++ b/debian/rules
@@ -5,13 +5,3 @@ export PYBUILD_NAME=catalog_validation
 
 %:
 	dh $@ --with python3 --buildsystem=pybuild
-
-override_dh_auto_install:
-	sh -c "\
-		mkdir -p debian/python3-catalog-validation/usr/sbin; \
-		curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 || exit 1; \
-		chmod 700 get_helm.sh || exit 1; \
-		export HELM_INSTALL_DIR=debian/python3-catalog-validation/usr/sbin; \
-		./get_helm.sh || exit 0; \
-	"
-	dh_auto_install;


### PR DESCRIPTION
This PR introduces following changes:

1) Allow validating item versions to be configurable
2) Do not install helm while packaging catalog_validation, the idea initially was to use this debian package in CI but later the approach taken was different and this is no longer required.