### PR TITLE
Increase timeout for installing k8s resources

### DIFF
--- a/catalog_validation/scripts/charts_validate.py
+++ b/catalog_validation/scripts/charts_validate.py
@@ -49,7 +49,7 @@ def deploy_charts(catalog_path, base_branch):
             [
                 'helm', 'install', chart_release_name, chart_path, '-n',
                 chart_release_name, '--create-namespace', '--wait',
-                '-f', os.path.join(chart_path, 'test_values.yaml'), '--debug',
+                '-f', os.path.join(chart_path, 'test_values.yaml'), '--debug', '--timeout', '600'
             ], env=env, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
         )
         stderr = cp.communicate(timeout=300)[1]


### PR DESCRIPTION
Large images like collabora can take some time to download which results in the existing command timing out. This commit increases the timeout value to avoid such cases.