### PR TITLE
Catalog validation failing due to minor schema issues

### DIFF
--- a/catalog_validation/schema/attrs.py
+++ b/catalog_validation/schema/attrs.py
@@ -97,6 +97,9 @@ class Schema:
                 },
             },
             'required': ['type'],
+            'dependencies': {
+                'show_subquestions_if': ['subquestions']
+            }
         }
         if self.DEFAULT_TYPE:
             schema['properties']['default'] = {
@@ -105,14 +108,15 @@ class Schema:
         if hasattr(self, 'enum'):
             schema['properties']['enum'] = {
                 'type': 'array',
-                'items': [{
+                'items': {
                     'type': 'object',
                     'properties': {
                         'value': {'type': [self.DEFAULT_TYPE] + (['null'] if self.null else [])},
                         'description': {'type': ['string', 'null']},
                     },
+                    'additionalProperties': False,
                     'required': ['value', 'description']
-                }]
+                },
             }
         return schema
 


### PR DESCRIPTION
### Problem:
- Catalog validation for **enum**  schema does not fail when unexpected key,values are added.
- Catalog validation does not fail when we add **subquestions** without adding **show_subquestions_if**.
### Solution:
- Added **additionalProperties: False** in **enum** schema under **items**  key and removed sqaure brackets **[ ]** form **items**.
- Added **dependencies** key in catalog validation schema.