### PR TITLE
Move logic from middleware to catalog_validation to retrieve catalog details

### DIFF
--- a/catalog_validation/items/catalog.py
+++ b/catalog_validation/items/catalog.py
@@ -1,0 +1,21 @@
+import concurrent.futures
+import os
+import typing
+
+from catalog_validation.utils import VALID_TRAIN_REGEX
+
+from .items_util import get_item_details
+
+
+def item_details(items: dict, location: str, questions_context: typing.Optional[dict], item_key: str):
+    train = items[item_key]
+    item = item_key.removesuffix(f'_{train}')
+    item_location = os.path.join(location, train, item)
+    return {
+        k: v for k, v in get_item_details(item_location, questions_context, {'retrieve_versions': True}).items()
+        if k != 'versions'
+    }
+
+
+
+

--- a/catalog_validation/items/catalog.py
+++ b/catalog_validation/items/catalog.py
@@ -18,7 +18,7 @@ def item_details(items: dict, location: str, questions_context: typing.Optional[
     }
 
 
-def retrieve_train_names(self, location, all_trains=True, trains_filter=None):
+def retrieve_train_names(location: str, all_trains=True, trains_filter=None):
     train_names = []
     trains_filter = trains_filter or []
     for train in os.listdir(location):

--- a/catalog_validation/items/catalog.py
+++ b/catalog_validation/items/catalog.py
@@ -17,5 +17,15 @@ def item_details(items: dict, location: str, questions_context: typing.Optional[
     }
 
 
-
-
+def retrieve_train_names(self, location, all_trains=True, trains_filter=None):
+    train_names = []
+    trains_filter = trains_filter or []
+    for train in os.listdir(location):
+        if (
+            not (all_trains or train in trains_filter) or not os.path.isdir(
+                os.path.join(location, train)
+            ) or train.startswith('.') or train in ('library', 'docs') or not VALID_TRAIN_REGEX.match(train)
+        ):
+            continue
+        train_names.append(train)
+    return train_names

--- a/catalog_validation/items/catalog.py
+++ b/catalog_validation/items/catalog.py
@@ -8,7 +8,7 @@ from catalog_validation.utils import VALID_TRAIN_REGEX
 from .items_util import get_item_details, get_default_questions_context
 
 
-def item_details(items: dict, location: str, questions_context: typing.Optional[dict], item_key: str):
+def item_details(items: dict, location: str, questions_context: typing.Optional[dict], item_key: str) -> dict:
     train = items[item_key]
     item = item_key.removesuffix(f'_{train}')
     item_location = os.path.join(location, train, item)
@@ -18,7 +18,7 @@ def item_details(items: dict, location: str, questions_context: typing.Optional[
     }
 
 
-def retrieve_train_names(location: str, all_trains=True, trains_filter=None):
+def retrieve_train_names(location: str, all_trains=True, trains_filter=None) -> list:
     train_names = []
     trains_filter = trains_filter or []
     for train in os.listdir(location):

--- a/catalog_validation/items/catalog.py
+++ b/catalog_validation/items/catalog.py
@@ -1,10 +1,11 @@
 import concurrent.futures
+import functools
 import os
 import typing
 
 from catalog_validation.utils import VALID_TRAIN_REGEX
 
-from .items_util import get_item_details
+from .items_util import get_item_details, get_default_questions_context
 
 
 def item_details(items: dict, location: str, questions_context: typing.Optional[dict], item_key: str):
@@ -29,3 +30,48 @@ def retrieve_train_names(self, location, all_trains=True, trains_filter=None):
             continue
         train_names.append(train)
     return train_names
+
+
+def get_items_in_trains(trains_to_traverse: list, catalog_location: str) -> dict:
+    items = {}
+    for train in trains_to_traverse:
+        items.update({
+            f'{i}_{train}': train for i in os.listdir(os.path.join(catalog_location, train))
+            if os.path.isdir(os.path.join(catalog_location, train, i))
+        })
+
+    return items
+
+
+def retrieve_trains_data(
+    items: dict, catalog_location: str, preferred_trains: list,
+    trains_to_traverse: list, job: typing.Any = None, questions_context: typing.Optional[dict] = None
+) -> typing.Tuple[dict, set]:
+    questions_context = questions_context or get_default_questions_context()
+    trains = {
+        'charts': {},
+        'test': {},
+        **{k: {} for k in trains_to_traverse},
+    }
+    unhealthy_apps = set()
+
+    total_items = len(items)
+    with concurrent.futures.ProcessPoolExecutor(max_workers=(5 if total_items > 10 else 2)) as exc:
+        for index, result in enumerate(zip(items, exc.map(
+            functools.partial(item_details, items, catalog_location, questions_context),
+            items, chunksize=(10 if total_items > 10 else 5)
+        ))):
+            item_key = result[0]
+            item_info = result[1]
+            train = items[item_key]
+            item = item_key.removesuffix(f'_{train}')
+            if job:
+                job.set_progress(
+                    int((index / total_items) * 80) + 10,
+                    f'Retrieved information of {item!r} item from {train!r} train'
+                )
+            trains[train][item] = item_info
+            if train in preferred_trains and not trains[train][item]['healthy']:
+                unhealthy_apps.add(f'{item} ({train} train)')
+
+    return trains, unhealthy_apps

--- a/catalog_validation/items/features.py
+++ b/catalog_validation/items/features.py
@@ -1,0 +1,19 @@
+SUPPORTED_FEATURES = {
+    'normalize/interfaceConfiguration',
+    'normalize/ixVolume',
+    'definitions/certificate',
+    'definitions/certificateAuthority',
+    'definitions/interface',
+    'definitions/gpuConfiguration',
+    'definitions/timezone',
+    'definitions/nodeIP',
+    'validations/containerImage',
+    'validations/nodePort',
+    'validations/hostPath',
+    'validations/lockedHostPath',
+    'validations/hostPathAttachments',
+}
+
+
+def version_supported(version_details: dict) -> bool:
+    return not bool(set(version_details['required_features']) - SUPPORTED_FEATURES)

--- a/catalog_validation/items/items_util.py
+++ b/catalog_validation/items/items_util.py
@@ -1,7 +1,6 @@
-import typing
-
 import markdown
 import os
+import typing
 import yaml
 
 from pkg_resources import parse_version
@@ -16,10 +15,13 @@ from .validate_utils import validate_item, validate_item_version
 ITEM_KEYS = ['icon_url']
 
 
-def get_item_details(item_location: str, questions_context: dict, options: dict) -> dict:
+def get_item_details(
+    item_location: str, questions_context: typing.Optional[dict] = None, options: typing.Optional[dict] = None
+) -> dict:
     item = item_location.rsplit('/', 1)[-1]
     train = item_location.rsplit('/', 2)[-2]
 
+    options = options or {}
     retrieve_versions = options.get('retrieve_versions', True)
     item_data = {
         'name': item,
@@ -76,7 +78,9 @@ def get_item_details(item_location: str, questions_context: dict, options: dict)
     return item_data
 
 
-def get_item_details_impl(item_path: str, schema: str, questions_context: dict, options: dict) -> dict:
+def get_item_details_impl(
+    item_path: str, schema: str, questions_context: typing.Optional[dict], options: typing.Optional[dict]
+) -> dict:
     # Each directory under item path represents a version of the item and we need to retrieve details
     # for each version available under the item
     retrieve_latest_version = options.get('retrieve_latest_version')
@@ -120,7 +124,7 @@ def get_item_details_impl(item_path: str, schema: str, questions_context: dict, 
 
 
 def get_item_version_details(
-    version_path: str, questions_context: dict, options: typing.Optional[dict] = None
+    version_path: str, questions_context: typing.Optional[dict], options: typing.Optional[dict] = None
 ) -> dict:
     version_data = {'location': version_path, 'required_features': set()}
     for key, filename, parser in (
@@ -138,7 +142,7 @@ def get_item_version_details(
 
     # We will normalise questions now so that if they have any references, we render them accordingly
     # like a field referring to available interfaces on the system
-    normalise_questions(version_data, questions_context)
+    normalise_questions(version_data, questions_context or get_default_questions_context())
 
     version_data.update({
         'supported': version_supported(version_data),
@@ -151,3 +155,15 @@ def get_item_version_details(
         version_data['human_version'] = f'{chart_metadata["appVersion"]}_{chart_metadata["version"]}'
 
     return version_data
+
+
+def get_default_questions_context() -> dict:
+    return {
+        'nic_choices': [],
+        'gpus': {},
+        'timezones': {'Asia/Saigon': 'Asia/Saigon', 'Asia/Damascus': 'Asia/Damascus'},
+        'node_ip': '192.168.0.10',
+        'certificates': [],
+        'certificate_authorities': [],
+        'system.general.config': {'timezone': 'America/Los_Angeles'},
+    }

--- a/catalog_validation/items/items_util.py
+++ b/catalog_validation/items/items_util.py
@@ -1,0 +1,153 @@
+import typing
+
+import markdown
+import os
+import yaml
+
+from pkg_resources import parse_version
+
+from catalog_validation.exceptions import ValidationErrors
+
+from .features import version_supported
+from .questions_utils import normalise_questions
+from .validate_utils import validate_item, validate_item_version
+
+
+ITEM_KEYS = ['icon_url']
+
+
+def get_item_details(item_location: str, questions_context: dict, options: dict) -> dict:
+    item = item_location.rsplit('/', 1)[-1]
+    train = item_location.rsplit('/', 2)[-2]
+
+    retrieve_versions = options.get('retrieve_versions', True)
+    item_data = {
+        'name': item,
+        'categories': [],
+        'app_readme': None,
+        'location': item_location,
+        'healthy': False,  # healthy means that each version the item hosts is valid and healthy
+        'healthy_error': None,  # An error string explaining why the item is not healthy
+        'versions': {},
+        'latest_version': None,
+        'latest_app_version': None,
+        'latest_human_version': None,
+    }
+
+    schema = f'{train}.{item}'
+    try:
+        validate_item(item_location, schema, False)
+    except ValidationErrors as verrors:
+        item_data['healthy_error'] = f'Following error(s) were found with {item!r}:\n'
+        for verror in verrors:
+            item_data['healthy_error'] += f'{verror[0]}: {verror[1]}'
+
+        # If the item format is not valid - there is no point descending any further into versions
+        if not retrieve_versions:
+            item_data.pop('versions')
+        return item_data
+
+    item_data.update(get_item_details_impl(item_location, schema, questions_context, {
+        'retrieve_latest_version': not retrieve_versions,
+        'default_values_callable': options.get('default_values_callable'),
+    }))
+    unhealthy_versions = []
+    for k, v in sorted(item_data['versions'].items(), key=lambda v: parse_version(v[0]), reverse=True):
+        if not v['healthy']:
+            unhealthy_versions.append(k)
+        else:
+            if not item_data['app_readme']:
+                item_data['app_readme'] = v['app_readme']
+            if not item_data['latest_version']:
+                item_data['latest_version'] = k
+                item_data['latest_app_version'] = v['chart_metadata'].get('appVersion')
+                item_data['latest_human_version'] = ''
+                if item_data['latest_app_version']:
+                    item_data['latest_human_version'] = f'{item_data["latest_app_version"]}_'
+                item_data['latest_human_version'] += k
+
+    if unhealthy_versions:
+        item_data['healthy_error'] = f'Errors were found with {", ".join(unhealthy_versions)} version(s)'
+    else:
+        item_data['healthy'] = True
+    if not retrieve_versions:
+        item_data.pop('versions')
+
+    return item_data
+
+
+def get_item_details_impl(item_path: str, schema: str, questions_context: dict, options: dict) -> dict:
+    # Each directory under item path represents a version of the item and we need to retrieve details
+    # for each version available under the item
+    retrieve_latest_version = options.get('retrieve_latest_version')
+    item_data = {'versions': {}}
+    with open(os.path.join(item_path, 'item.yaml'), 'r') as f:
+        item_data.update(yaml.safe_load(f.read()))
+
+    item_data.update({k: item_data.get(k) for k in ITEM_KEYS})
+
+    for version in sorted(
+        filter(lambda p: os.path.isdir(os.path.join(item_path, p)), os.listdir(item_path)),
+        reverse=True, key=parse_version,
+    ):
+        item_data['versions'][version] = version_details = {
+            'healthy': False,
+            'supported': False,
+            'healthy_error': None,
+            'location': os.path.join(item_path, version),
+            'required_features': [],
+            'human_version': version,
+            'version': version,
+        }
+        try:
+            validate_item_version(version_details['location'], f'{schema}.{version}')
+        except ValidationErrors as verrors:
+            version_details['healthy_error'] = f'Following error(s) were found with {schema}.{version!r}:\n'
+            for verror in verrors:
+                version_details['healthy_error'] += f'{verror[0]}: {verror[1]}'
+
+            # There is no point in trying to see what questions etc the version has as it's invalid
+            continue
+
+        version_details.update({
+            'healthy': True,
+            **get_item_version_details(version_details['location'], questions_context)
+        })
+        if retrieve_latest_version:
+            break
+
+    return item_data
+
+
+def get_item_version_details(
+    version_path: str, questions_context: dict, options: typing.Optional[dict] = None
+) -> dict:
+    version_data = {'location': version_path, 'required_features': set()}
+    for key, filename, parser in (
+        ('chart_metadata', 'Chart.yaml', yaml.safe_load),
+        ('schema', 'questions.yaml', yaml.safe_load),
+        ('app_readme', 'app-readme.md', markdown.markdown),
+        ('detailed_readme', 'README.md', markdown.markdown),
+        ('changelog', 'CHANGELOG.md', markdown.markdown),
+    ):
+        if os.path.exists(os.path.join(version_path, filename)):
+            with open(os.path.join(version_path, filename), 'r') as f:
+                version_data[key] = parser(f.read())
+        else:
+            version_data[key] = None
+
+    # We will normalise questions now so that if they have any references, we render them accordingly
+    # like a field referring to available interfaces on the system
+    normalise_questions(version_data, questions_context)
+
+    version_data.update({
+        'supported': version_supported(version_data),
+        'required_features': list(version_data['required_features']),
+    })
+    if options and options.get('default_values_callable'):
+        version_data['values'] = options['default_values_callable'](version_data)
+    chart_metadata = version_data['chart_metadata']
+    if chart_metadata['name'] != 'ix-chart' and chart_metadata.get('appVersion'):
+        version_data['human_version'] = f'{chart_metadata["appVersion"]}_{chart_metadata["version"]}'
+
+    return version_data

--- a/catalog_validation/items/questions_utils.py
+++ b/catalog_validation/items/questions_utils.py
@@ -1,0 +1,77 @@
+import itertools
+
+
+def normalise_questions(version_data: dict, context: dict) -> None:
+    version_data['required_features'] = set()
+    for question in version_data['schema']['questions']:
+        normalise_question(question, version_data, context)
+    version_data['required_features'] = list(version_data['required_features'])
+
+
+def normalise_question(question: dict, version_data: dict, context: dict) -> None:
+    schema = question['schema']
+    for attr in itertools.chain(*[schema.get(k, []) for k in ('attrs', 'items', 'subquestions')]):
+        normalise_question(attr, version_data, context)
+
+    if '$ref' not in schema:
+        return
+
+    data = {}
+    for ref in schema['$ref']:
+        version_data['required_features'].add(ref)
+        if ref == 'definitions/interface':
+            data['enum'] = [
+                {'value': i, 'description': f'{i!r} Interface'} for i in context['nic_choices']
+            ]
+        elif ref == 'definitions/gpuConfiguration':
+            data['attrs'] = [
+                {
+                    'variable': gpu,
+                    'label': f'GPU Resource ({gpu})',
+                    'description': 'Please enter the number of GPUs to allocate',
+                    'schema': {
+                        'type': 'int',
+                        'max': int(quantity),
+                        'enum': [
+                            {'value': i, 'description': f'Allocate {i!r} {gpu} GPU'}
+                            for i in range(int(quantity) + 1)
+                        ],
+                        'default': 0,
+                    }
+                } for gpu, quantity in context['gpus'].items()
+            ]
+        elif ref == 'definitions/timezone':
+            data.update({
+                'enum': [{'value': t, 'description': f'{t!r} timezone'} for t in sorted(context['timezones'])],
+                'default': context['system.general.config']['timezone']
+            })
+        elif ref == 'definitions/nodeIP':
+            data['default'] = context['node_ip']
+        elif ref == 'definitions/certificate':
+            get_cert_ca_options(schema, data, {'value': None, 'description': 'No Certificate'})
+            data['enum'] += [
+                {'value': i['id'], 'description': f'{i["name"]!r} Certificate'}
+                for i in context['certificates']
+            ]
+        elif ref == 'definitions/certificateAuthority':
+            get_cert_ca_options(schema, data, {'value': None, 'description': 'No Certificate Authority'})
+            data['enum'] += [{'value': None, 'description': 'No Certificate Authority'}] + [
+                {'value': i['id'], 'description': f'{i["name"]!r} Certificate Authority'}
+                for i in context['certificate_authorities']
+            ]
+
+    schema.update(data)
+
+
+def get_cert_ca_options(schema: dict, data: dict, default_entry: dict):
+    if schema.get('null', True):
+        data.update({
+            'enum': [default_entry],
+            'default': None,
+            'null': True,
+        })
+    else:
+        data.update({
+            'enum': [],
+            'required': True,
+        })

--- a/catalog_validation/items/validate_utils.py
+++ b/catalog_validation/items/validate_utils.py
@@ -1,0 +1,9 @@
+from catalog_validation.validation import validate_catalog_item, validate_catalog_item_version
+
+
+def validate_item(path: str, schema: str, validate_versions: bool = True):
+    validate_catalog_item(path, schema, validate_versions)
+
+
+def validate_item_version(path: str, schema: str):
+    validate_catalog_item_version(path, schema)


### PR DESCRIPTION
This PR introduces changes to move logic from middleware to catalog_validation so that we can have a github action update catalog information on each master push to truenas/charts and the same code can be reused in middleware by importing the library.