### PR TITLE
Add unit tests for catalog validation logic

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,24 @@
+name: catalog_validation_test
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r catalog_validation/pytest/requirements.txt
+        pip install -r requirements.txt
+    - name: Installing catalog validation
+      run: python setup.py install
+    - name: Running test
+      run: pytest catalog_validation/pytest/

--- a/catalog_validation/pytest/requirements.txt
+++ b/catalog_validation/pytest/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-mock

--- a/catalog_validation/pytest/unit/test_catalog_validate.py
+++ b/catalog_validation/pytest/unit/test_catalog_validate.py
@@ -1,0 +1,189 @@
+import pytest
+
+from catalog_validation.exceptions import ValidationErrors
+from catalog_validation.utils import WANTED_FILES_IN_ITEM_VERSION
+from catalog_validation.validation import (
+    validate_train_structure, validate_questions_yaml, validate_catalog_item, validate_catalog_item_version,
+)
+
+
+@pytest.mark.parametrize('train_path,should_work', [
+    ('/mnt/mypool/ix-applications/catalogs/github_com_truenas_charts_git_master/charts', True),
+    ('/mnt/mypool/ix-applications/catalogs/github_com_truenas_charts_git_master/charts/', False),
+
+])
+def test_validate_train_structure(train_path, should_work):
+    if should_work:
+        assert validate_train_structure(train_path) is None
+    else:
+        with pytest.raises(ValidationErrors):
+            validate_train_structure(train_path)
+
+
+@pytest.mark.parametrize('test_yaml,should_work', [
+    (
+        '''
+            groups:
+              - name: "Machinaris Configuration"
+                description: "Configure timezone for machianaris"
+
+            portals:
+              web_portal:
+                protocols:
+                  - "http"
+                host:
+                  - "$node_ip"
+                ports:
+                  - "$variable-machinaris_ui_port"
+
+            questions:
+              - variable: timezone
+                label: "Configure timezone"
+                group: "Machinaris Configuration"
+                description: "Configure timezone for machianaris"
+        ''',
+        True
+    ),
+    (
+        '''
+            groups:
+              - name: "Machinaris Configuration"
+                description: "Configure timezone for machianaris"
+
+            portals:
+              web_portal:
+                protocols: {}
+                host: {}
+                ports: {}
+
+            questions:
+              - variable: timezone
+                label: "Configure timezone"
+                group: "Machinaris Configuration"
+                description: "Configure timezone for machianaris"
+        ''',
+        False
+    ),
+    (
+        '''
+        questions:
+          - variable: timezone
+            label: "Configure timezone"
+            group: "Machinaris Configuration"
+            description: "Configure timezone for machianaris"
+        ''',
+        False
+    ),
+    (
+        '''
+            groups:
+              - name: "Machinaris Configuration"
+                description: "Configure timezone for machianaris"
+
+            questions:
+              - variable: timezone
+                label: "Configure timezone"
+                group: "Machinaris Configuration"
+                description: "Configure timezone for machianaris"
+        ''',
+        True
+    ),
+    (
+        '''
+            groups:
+              - name: "Machinaris Configuration"
+                description: "Configure timezone for machianaris"
+
+            questions:
+              - variable: timezone
+                label: "Network"
+                group: "Machinaris Network Configuration"
+                description: "Configure timezone for machianaris"
+
+        ''',
+        False
+    ),
+
+])
+def test_validate_questions_yaml(mocker, test_yaml, should_work):
+    open_file_data = mocker.mock_open(read_data=test_yaml)
+    mocker.patch('builtins.open', open_file_data)
+    mocker.patch('catalog_validation.validation.validate_question', return_value=None)
+    if should_work:
+        assert validate_questions_yaml(None, 'charts.machinaris.versions.1.1.13.questions_configuration') is None
+    else:
+        with pytest.raises(ValidationErrors):
+            validate_questions_yaml(None, 'charts.machinaris.versions.1.1.13.questions_configuration')
+
+
+@pytest.mark.parametrize('catalog_item_path,test_yaml,should_work', [
+    (
+        '/mnt/mypool/ix-applications/catalogs/github_com_truenas_charts_git_master/charts/machinaris',
+        '''
+         categories:
+           - storage
+           - crypto
+         icon_url: https://raw.githubusercontent.com/guydavis/machinaris/main/web/static/machinaris.png
+        ''',
+        True
+    ),
+    (
+        '/mnt/mypool/ix-applications/catalogs/github_com_truenas_charts_git_master/charts/machinaris',
+        '''
+            icon_url: https://raw.githubusercontent.com/guydavis/machinaris/main/web/static/machinaris.png
+        ''',
+        False
+    ),
+])
+def test_validate_catalog_item(mocker, catalog_item_path, test_yaml, should_work):
+    mocker.patch('os.path.isdir', side_effect=[True, True, False])
+    mocker.patch('os.listdir', return_value=['1.1.13', 'item.yaml'])
+    open_file_data = mocker.mock_open(read_data=test_yaml)
+    mocker.patch('builtins.open', open_file_data)
+    mocker.patch('catalog_validation.validation.validate_catalog_item_version', return_value=None)
+    if not should_work:
+        with pytest.raises(ValidationErrors):
+            validate_catalog_item(catalog_item_path, 'charts.machinaris')
+    else:
+        assert validate_catalog_item(catalog_item_path, 'charts.machinaris') is None
+
+
+@pytest.mark.parametrize('chart_yaml,should_work', [
+    (
+        '''
+        name: storj
+        version: 1.0.4
+        ''',
+        True
+    ),
+    (
+        '''
+        name: storj
+        version: 1.0.0
+        ''',
+        False
+    ),
+    (
+        '''
+        name: storj_s
+        version: 1.0.0
+        ''',
+        False
+    )
+])
+def test_validate_catalog_item_version(mocker, chart_yaml, should_work):
+    mocker.patch('os.listdir', return_value=WANTED_FILES_IN_ITEM_VERSION)
+    mocker.patch('os.path.exists', return_value=True)
+    open_file = mocker.mock_open(read_data=chart_yaml)
+    mocker.patch('builtins.open', open_file)
+    mocker.patch('catalog_validation.validation.validate_questions_yaml', return_value=None)
+    if should_work:
+        assert validate_catalog_item_version(
+            '/mnt/mypool/ix-applications/catalogs/github_com_truenas_charts_git_master/charts/storj/1.0.4',
+            'charts.storj.versions.1.0.4') is None
+    else:
+        with pytest.raises(ValidationErrors):
+            validate_catalog_item_version(
+                '/mnt/mypool/ix-applications/catalogs/github_com_truenas_charts_git_master/charts/storj/1.0.4',
+                'charts.storj.versions.1.0.4'
+            )

--- a/catalog_validation/pytest/unit/test_items_util.py
+++ b/catalog_validation/pytest/unit/test_items_util.py
@@ -1,0 +1,88 @@
+import pytest
+
+from catalog_validation.items.items_util import get_item_details, get_item_details_impl
+
+
+QUESTION_CONTEXT = {
+    'nic_choices': [],
+    'gpus': {},
+    'timezones': {'Asia/Saigon': 'Asia/Saigon', 'Asia/Damascus': 'Asia/Damascus'},
+    'node_ip': '192.168.0.10',
+    'certificates': [],
+    'certificate_authorities': [],
+    'system.general.config': {'timezone': 'America/Los_Angeles'},
+}
+
+
+@pytest.mark.parametrize('item_location,options,items_data', [
+    ('/mnt/mypool/ix-applications/catalogs/github_com_truenas_charts_git_master/charts/chia',
+     {'retrieve_versions': True},
+     {
+         'name': 'chia',
+         'categories': [],
+         'app_readme': None,
+         'location': '/mnt/mypool/ix-applications/catalogs/github_com_truenas_charts_git_master/charts/chia',
+         'healthy': True,
+         'healthy_error': None,
+         'versions': {},
+         'latest_version': None,
+         'latest_app_version': None,
+         'latest_human_version': None
+     }
+     ),
+])
+def test_get_item_details(mocker, item_location, options, items_data):
+    mocker.patch('catalog_validation.items.items_util.validate_item', return_value=None)
+    mocker.patch('catalog_validation.items.items_util.get_item_details_impl', return_value={})
+    assert get_item_details(item_location, QUESTION_CONTEXT, options) == items_data
+
+
+@pytest.mark.parametrize('item_path,schema,options,yaml_data,item_data_impl,open_yaml', [
+    (
+        '/mnt/mypool/ix-applications/catalogs/github_com_truenas_charts_git_master/charts/chia',
+        'charts.chia',
+        {'retrieve_latest_version': True}, {
+            'variable': 'web_port',
+            'label': 'Web Port for Diskover',
+            'group': 'Networking',
+            'schema': {
+                'type': 'int',
+                'min': 8000,
+                'max': 65535,
+                'default': 22510,
+                'required': True
+            }
+        }, {
+            'versions': {
+                '1.3.37': {
+                    'healthy': True,
+                    'supported': False,
+                    'healthy_error': None,
+                    'location': '/mnt/mypool/ix-applications/catalogs/github_com_truenas_'
+                                'charts_git_master/charts/chia/1.3.37',
+                    'required_features': [],
+                    'human_version': '1.3.37',
+                    'version': '1.3.37'
+                }
+            },
+            'categories': ['storage', 'crypto'],
+            'icon_url': 'https://www.chia.net/wp-content/uploads/2022/09/chia-logo.svg'
+        },
+        '''
+        categories:
+          - storage
+          - crypto
+        icon_url: https://www.chia.net/wp-content/uploads/2022/09/chia-logo.svg
+        '''
+    ),
+])
+def test_get_item_details_impl(
+    mocker, item_path, schema, options, yaml_data, item_data_impl, open_yaml,
+):
+    open_file_data = mocker.mock_open(read_data=open_yaml)
+    mocker.patch('builtins.open', open_file_data)
+    mocker.patch('os.path.isdir', return_value=True)
+    mocker.patch('os.listdir', return_value=['upgrade_info.json', '1.3.37', 'upgrade_strategy', 'item.yaml'])
+    mocker.patch('catalog_validation.items.items_util.validate_item_version', return_value=None)
+    mocker.patch('catalog_validation.items.items_util.get_item_version_details', return_value={})
+    assert get_item_details_impl(item_path, schema, QUESTION_CONTEXT, options) == item_data_impl

--- a/catalog_validation/pytest/unit/test_normalise_questions.py
+++ b/catalog_validation/pytest/unit/test_normalise_questions.py
@@ -1,0 +1,321 @@
+from catalog_validation.items.questions_utils import normalise_question
+import pytest
+
+
+VERSION_DATA = {
+    'location': '/mnt/mypool/ix-applications/catalogs/github_com_truenas_charts_git_master/charts/syncthing/1.0.14',
+    'required_features': {
+        'normalize/ixVolume',
+        'validations/lockedHostPath',
+    },
+    'chart_metadata': {},
+    'schema': {
+        'variable': 'hostNetwork',
+        'label': 'Host Network',
+        'group': 'Networking',
+    },
+    'app_readme': 'there is not any',
+    'detailed_readme': 'there is not any',
+    'changelog': None,
+}
+
+
+@pytest.mark.parametrize('question,normalise_data,context', [
+    (
+        {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/interface'],
+            }
+        }, {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/interface'],
+                'enum': [],
+            }
+        }, {
+            'nic_choices': [],
+        }
+    ),
+    (
+        {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/interface'],
+            }
+        }, {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/interface'],
+                'enum': [{
+                    'value': 'ens0',
+                    'description': "'ens0' Interface"
+                }],
+            }
+        }, {
+            'nic_choices': ['ens0']
+        }
+    ),
+    (
+        {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/gpuConfiguration'],
+            }
+        }, {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/gpuConfiguration'],
+                'attrs': [{
+                    'variable': 'test@gpu',
+                    'label': 'GPU Resource (test@gpu)',
+                    'description': 'Please enter the number of GPUs to allocate',
+                    'schema': {
+                        'type': 'int',
+                        'max': 3,
+                        'enum': [
+                            {'value': i, 'description': f'Allocate {i!r} test@gpu GPU'}
+                            for i in range(4)
+                        ],
+                        'default': 0,
+                    }
+                }],
+            }
+        }, {
+            'gpus': {
+                'test@gpu': 3
+            }
+        }
+    ),
+    (
+        {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/gpuConfiguration'],
+            }
+        }, {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/gpuConfiguration'],
+                'attrs': [],
+            }
+        }, {
+            'gpus': {}
+        }
+    ),
+    (
+        {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/timezone'],
+            }
+        }, {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/timezone'],
+                'enum': [{
+                    'value': 'Asia/Damascus',
+                    'description': "'Asia/Damascus' timezone",
+                }, {
+                    'value': 'Asia/Saigon',
+                    'description': "'Asia/Saigon' timezone",
+                }],
+                'default': 'America/Los_Angeles',
+            }
+        },
+        {
+            'timezones': {
+                'Asia/Saigon': 'Asia/Saigon',
+                'Asia/Damascus': 'Asia/Damascus',
+            },
+            'system.general.config': {
+                'timezone': 'America/Los_Angeles',
+            }
+        }
+    ),
+    (
+        {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/nodeIP'],
+            }
+        }, {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/nodeIP'],
+                'default': '192.168.0.10',
+            }
+        },
+        {
+            'node_ip': '192.168.0.10'
+        }
+    ),
+    (
+        {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/certificate'],
+            }
+        }, {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/certificate'],
+                'enum': [{
+                    'value': None,
+                    'description': 'No Certificate'
+                },
+                    {
+                        'value': '1',
+                        'description': "'testcert' Certificate"
+                    }
+                ],
+                'default': None,
+                'null': True
+            }
+        }, {'certificates': [{
+            'id': '1',
+            'name': 'testcert'
+        }],
+        }
+    ),
+    (
+        {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/certificate'],
+            }
+        }, {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/certificate'],
+                'enum': [{
+                    'value': None,
+                    'description': 'No Certificate'
+                }],
+                'default': None,
+                'null': True
+            }
+        }, {
+            'certificates': []
+        }
+    ),
+    (
+        {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/certificateAuthority'],
+            }
+        }, {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/certificateAuthority'],
+                'enum': [{
+                    'value': None,
+                    'description': 'No Certificate Authority'
+                }, {
+                    'value': None,
+                    'description': 'No Certificate Authority'
+                }],
+                'default': None,
+                'null': True
+            }
+        }, {
+            'certificate_authorities': []
+        }
+    ),
+    (
+        {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/certificateAuthority'],
+            }
+        }, {
+            'variable': 'datasetName',
+            'label': 'Plots Volume Name',
+            'schema': {
+                'type': 'string',
+                'hidden': True,
+                '$ref': ['definitions/certificateAuthority'],
+                'enum': [{
+                    'value': None,
+                    'description': 'No Certificate Authority'
+                }, {
+                    'value': None,
+                    'description': 'No Certificate Authority'
+                },
+                    {
+                        'value': '1',
+                        'description': "'testca' Certificate Authority"
+                    }
+                ],
+                'default': None,
+                'null': True
+            }
+        }, {
+            'certificate_authorities': [{
+                'id': '1',
+                'name': 'testca'
+            }],
+        }
+    )
+])
+def test_normalise_question(question, normalise_data, context):
+    normalise_question(question, VERSION_DATA, context)
+    assert question == normalise_data

--- a/catalog_validation/pytest/unit/test_schema.py
+++ b/catalog_validation/pytest/unit/test_schema.py
@@ -1,0 +1,577 @@
+import pytest
+
+from catalog_validation.schema.schema_gen import get_schema
+from catalog_validation.exceptions import ValidationErrors
+from catalog_validation.validation import validate_question
+
+
+@pytest.mark.parametrize('schema,should_work', [
+    (
+        {
+            'type': 'dict',
+            'attrs': []
+        },
+        True
+    ),
+    (
+        {
+            'type': 'dict',
+            'attrs': {}
+        },
+        False
+    ),
+    (
+        {
+            'type': 'list'
+        },
+        False
+    ),
+    (
+        {
+            'type': 'list',
+            'items': []
+        },
+        True
+    ),
+    (
+        {
+            'type': 'list',
+            'items': {}
+        },
+        False
+    ),
+    (
+        {
+            'type': 'string',
+            'editable': True
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            'default': 'hello'
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            'default': 1
+        },
+        False
+    ),
+    (
+        {
+            'type': 'string',
+            'editable': 'true'
+        },
+        False
+    ),
+    (
+        {
+            'type': 'string',
+            'private': True
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            'private': 'true'
+        },
+        False
+    ),
+    (
+        {
+            'type': 'string',
+            'max_length': 233
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            'max_length': '233'
+        },
+        False
+    ),
+    (
+        {
+            'type': 'string',
+            'min_length': 233
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            'min_length': '233'
+        },
+        False
+    ),
+    (
+        {
+            'type': 'string',
+            'valid_chars': '[a-z]*'
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            'valid_chars': ['a-z']
+        },
+        False
+    ),
+    (
+        {
+            'type': 'string', 'null': True
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            'null': 'true'
+        }, False
+    ),
+    (
+        {
+            'type': 'string',
+            'immutable': True
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            'immutable': 'true'
+        },
+        False
+    ),
+    (
+        {
+            'type': 'string',
+            'required': True
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            'required': 'true'
+        },
+        False
+    ),
+    (
+        {
+            'type': 'string',
+            'hidden': True
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            'hidden': 'true'
+        },
+        False
+    ),
+    (
+        {
+            'type': 'string',
+            'show_if': 'true'
+        },
+        False
+    ),
+    (
+        {
+            'type': 'string',
+            'show_if': [['hello', '=', 'world']]
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            'subquestions': []
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            'subquestions': {}
+        },
+        False
+    ),
+    (
+        {
+            'type': 'string',
+            'show_subquestions_if': None
+        }, False
+    ),
+    (
+        {
+            'type': 'string',
+            'show_subquestions_if': None,
+            'subquestions': []
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            'show_subquestions_if': 1,
+            'subquestions': []
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            'show_subquestions_if': 'test',
+            'subquestions': []
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            'show_subquestions_if': {},
+            'subquestions': []
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            'show_subquestions_if': [],
+            'subquestions': []
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            '$ui-ref': []
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            '$ui-ref': {}
+        },
+        False
+    ),
+    (
+        {
+            'type': 'string',
+            '$ref': []
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            '$ref': {}
+        },
+        False
+    ),
+    (
+        {
+            'type': 'int',
+            'min': 233,
+            'max': 2311
+        },
+        True
+    ),
+    (
+        {
+            'type': 'int',
+            'min': '233',
+            'max': 2311
+        },
+        False
+    ),
+    (
+        {
+            'type': 'int',
+            'min': 233,
+            'max': '2311'
+        },
+        False
+    ),
+    (
+        {
+            'type': 'int',
+            'default': 23
+        },
+        True
+    ),
+    (
+        {
+            'type': 'int',
+            'default': '23'
+        },
+        False
+    ),
+    (
+        {
+            'type': 'ipaddr',
+            'ipv4': True,
+            'ipv6': False,
+            'cidr': True
+        },
+        True
+    ),
+    (
+        {
+            'type': 'ipaddr',
+            'ipv4': True,
+            'ipv6': False,
+            'cidr': 'true'
+        },
+        False
+    ),
+    (
+        {
+            'type': 'ipaddr',
+            'ipv4': True,
+            'ipv6': 'False',
+            'cidr': True
+        },
+        False
+    ),
+    (
+        {
+            'type': 'ipaddr',
+            'ipv4': 'True',
+            'ipv6': False,
+            'cidr': True
+        },
+        False
+    ),
+    (
+        {
+            'type': 'string',
+            'enum': [{
+                'value': 'test',
+                'description': 'test'
+            }]
+        },
+        True
+    ),
+    (
+        {
+            'type': 'string',
+            'enum': [{
+                'value': 'test',
+                'description': 'test',
+                'obj': {}
+            }]
+        },
+        False
+    ),
+    (
+        {
+            'type': 'string',
+            'enum': [{
+                'value': 'test'
+            }]
+        },
+        False
+    ),
+    (
+        {
+            'type': 'string',
+            'enum': [{
+                'key': 'value'
+            }]
+        },
+        False
+    ),
+    (
+        {
+            'type': 'string',
+            'enum': [{}]
+        },
+        False
+    ),
+    (
+        {
+            'type': 'hostpath'
+        },
+        True
+    ),
+    (
+        {
+            'type': 'hostpath',
+            'default': '/root/'
+        },
+        True
+    ),
+    (
+        {
+            'type': 'hostpath',
+            'default': 231
+        },
+        False
+    ),
+    (
+        {
+            'type': 'path'
+        },
+        True
+    ),
+    (
+        {
+            'type': 'path',
+            'default': '/root/'
+        },
+        True
+    ),
+    (
+        {
+            'type': 'path',
+            'default': 231
+        },
+        False
+    ),
+    (
+        {
+            'type': 'boolean'
+        },
+        True
+    ),
+    (
+        {
+            'type': 'boolean',
+            'default': True
+        },
+        True
+    ),
+    (
+        {
+            'type': 'boolean',
+            'default': 'true'
+        },
+        False
+    ),
+    (
+        {
+            'type': 'cron'
+        },
+        True
+    ),
+    (
+        {
+            'type': 'cron',
+            'default': {}
+        },
+        True
+    ),
+    (
+        {
+            'type': 'cron',
+            'default': []
+        },
+        False
+    ),
+    (
+        {
+            'type': 'uri'
+        },
+        True
+    ),
+    (
+        {
+            'type': 'uri',
+            'default': 'http://www.google.com'
+        },
+        True
+    ),
+    (
+        {
+            'type': 'uri',
+            'default': 2133
+        },
+        False
+    ),
+])
+def test_schema_validation(schema, should_work):
+    if not should_work:
+        with pytest.raises(ValidationErrors):
+            get_schema(schema).validate('')
+    else:
+        assert get_schema(schema).validate('') is None
+
+
+@pytest.mark.parametrize('variable,should_work', [
+    (
+        {
+            'variable': 'testing',
+            'label': 'Testing',
+            'description': 'for testing',
+            'group': 'testing',
+            'schema': {
+                'type': 'boolean',
+                'default': True
+            }
+        },
+        True
+    ),
+    (
+        {
+            'variable': 'testing',
+            'description': 'for testing',
+            'group': 'testing',
+            'schema': {
+                'type': 'boolean',
+                'default': True
+            }
+        },
+        False
+    ),
+    (
+        {
+            'variable': 'testing',
+            'label': 'Testing',
+            'description': 'for testing'
+        },
+        False
+    ),
+    (
+        {
+            'variable': 'testing',
+            'label': 'Testing',
+            'description': 'for testing',
+            'schema': {
+                'type': 'boolean',
+                'default': True
+            }
+        },
+        True
+    ),
+    (
+        {
+            'variable': 'testing',
+            'label': 'Testing',
+            'description': 'for testing',
+            'schema': {
+                'default': True
+            }
+        },
+        False
+    ),
+])
+def test_question_variable_validation(variable, should_work):
+    verrors = ValidationErrors()
+    validate_question(variable, '', verrors)
+    if not should_work:
+        with pytest.raises(ValidationErrors):
+            verrors.check()
+    else:
+        verrors.check()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jsonschema
+jsonschema==3.2.0
 kubernetes
 markdown
 pyyaml


### PR DESCRIPTION
## Context

Unit tests have been added for following scenarios:

1. Catalog validation logic
2. Parsing item details
3. Normalizing questions in an item's questions.yaml