### PR TITLE
Add ability to specify application metadata

### DIFF
--- a/catalog_validation/items/items_util.py
+++ b/catalog_validation/items/items_util.py
@@ -155,6 +155,7 @@ def get_item_version_details(
     version_data = {'location': version_path, 'required_features': set()}
     for key, filename, parser in (
         ('chart_metadata', 'Chart.yaml', yaml.safe_load),
+        ('app_metadata', 'metadata.yaml', yaml.safe_load),
         ('schema', 'questions.yaml', yaml.safe_load),
         ('app_readme', 'app-readme.md', markdown.markdown),
         ('detailed_readme', 'README.md', markdown.markdown),

--- a/catalog_validation/utils.py
+++ b/catalog_validation/utils.py
@@ -2,6 +2,47 @@ import re
 
 
 CACHED_CATALOG_FILE_NAME = 'catalog.json'
+METADATA_JSON_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'runAsContext': {
+            'type': 'array',
+            'items': {
+                'type': 'object',
+                'properties': {
+                    'description': {'type': 'string'},
+                    'gid': {'type': 'integer'},
+                    'groupName': {'type': 'string'},
+                    'userName': {'type': 'string'},
+                    'uid': {'type': 'integer'},
+                },
+                'required': ['description'],
+            },
+        },
+        'capabilities': {
+            'type': 'array',
+            'items': {
+                'type': 'object',
+                'properties': {
+                    'description': {'type': 'string'},
+                    'name': {'type': 'string'},
+                },
+                'required': ['description', 'name'],
+            },
+        },
+        'hostMounts': {
+            'type': 'array',
+            'items': {
+                'type': 'object',
+                'properties': {
+                    'description': {'type': 'string'},
+                    'hostPath': {'type': 'string'},
+                },
+                'required': ['description', 'hostPath'],
+            },
+        },
+    },
+}
 VALID_TRAIN_REGEX = re.compile(r'^\w+[\w.-]*$')
 WANTED_FILES_IN_ITEM_VERSION = {'questions.yaml', 'app-readme.md', 'Chart.yaml', 'README.md'}
 


### PR DESCRIPTION
## Context

For most cases we would want app developers to be limited to what they try to consume from the host but in some cases it is necessary for the app to function.
A good example is `netdata` application, in order for it to gather statistics it needs access to sysfs which is fine but an end user should be aware of what the app in question is trying to consume. Changes have been made which expose the following information for now and we can extend this as required:
```
runAsContext:
  - userName: root
     groupName: root
     gid: 0
     uid: 0
     description: "Why this needs to be done"
capabilities:
  - name: SYS_PTRACE
    description: "This is being used to do X thing"
hostMounts:
  - hostPath: "/proc"
    description: "Required by netdata for xyz"
```