### PR TITLE
Add last update field for apps and app versions

### DIFF
--- a/catalog_validation/items/items_util.py
+++ b/catalog_validation/items/items_util.py
@@ -9,6 +9,7 @@ from catalog_validation.exceptions import ValidationErrors
 
 from .features import version_supported
 from .questions_utils import normalise_questions
+from .utils import get_last_updated_date
 from .validate_utils import validate_item, validate_item_version
 
 
@@ -18,6 +19,7 @@ ITEM_KEYS = ['icon_url']
 def get_item_details(
     item_location: str, questions_context: typing.Optional[dict] = None, options: typing.Optional[dict] = None
 ) -> dict:
+    catalog_path = item_location.rstrip('/').rsplit('/', 2)[0]
     item = item_location.rsplit('/', 1)[-1]
     train = item_location.rsplit('/', 2)[-2]
 
@@ -33,6 +35,7 @@ def get_item_details(
         'latest_version': None,
         'latest_app_version': None,
         'latest_human_version': None,
+        'last_update': get_last_updated_date(catalog_path, item_location),
         'name': item,
         'title': item.capitalize(),
         'versions': {},
@@ -100,11 +103,14 @@ def get_item_details_impl(
         filter(lambda p: os.path.isdir(os.path.join(item_path, p)), os.listdir(item_path)),
         reverse=True, key=parse_version,
     ):
+        catalog_path = item_path.rstrip('/').rsplit('/', 2)[0]
+        version_path = os.path.join(item_path, version)
         item_data['versions'][version] = version_details = {
             'healthy': False,
             'supported': False,
             'healthy_error': None,
-            'location': os.path.join(item_path, version),
+            'location': version_path,
+            'last_update': get_last_updated_date(catalog_path, version_path),
             'required_features': [],
             'human_version': version,
             'version': version,

--- a/catalog_validation/items/utils.py
+++ b/catalog_validation/items/utils.py
@@ -1,3 +1,10 @@
+import contextlib
+import git
+
+from datetime import datetime
+from typing import Optional
+
+
 def get_catalog_json_schema() -> dict:
     return {
         'type': 'object',
@@ -62,3 +69,15 @@ def get_catalog_json_schema() -> dict:
             }
         }
     }
+
+
+def get_last_updated_date(repo_path: str, folder_path: str) -> Optional[str]:
+    with contextlib.suppress(Exception):
+        # We don't want to fail querying items if for whatever reason this fails
+        repo = git.Repo(repo_path)
+        latest_commit = next(repo.iter_commits(paths=folder_path, max_count=1), None)
+        if latest_commit:
+            timestamp = datetime.fromtimestamp(latest_commit.committed_date)
+            return timestamp.strftime('%Y-%m-%d %H:%M:%S')
+        else:
+            return None

--- a/catalog_validation/pytest/unit/test_items_util.py
+++ b/catalog_validation/pytest/unit/test_items_util.py
@@ -24,6 +24,7 @@ QUESTION_CONTEXT = {
          'location': '/mnt/mypool/ix-applications/catalogs/github_com_truenas_charts_git_master/charts/chia',
          'healthy': True,
          'healthy_error': None,
+         'last_update': None,
          'versions': {},
          'latest_version': None,
          'latest_app_version': None,
@@ -60,6 +61,7 @@ def test_get_item_details(mocker, item_location, options, items_data):
                     'healthy': True,
                     'supported': False,
                     'healthy_error': None,
+                    'last_update': None,
                     'location': '/mnt/mypool/ix-applications/catalogs/github_com_truenas_'
                                 'charts_git_master/charts/chia/1.3.37',
                     'required_features': [],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+gitpython
 jsonschema==3.2.0
 kubernetes
 markdown


### PR DESCRIPTION
## Context

UI team has requested to have a `last_update` field for newer Apps UI. This posed a problem wrt performance and the solution to that has been to add this field to the cached metadata file for each catalog which is generated on the catalog side, hence middleware is spared the overhead which would not have been possible to manage otherwise.

It will show up in the following format currently:
```
"last_update": "2023-02-01 22:55:31",
```