### PR TITLE
NAS-120548 / 23.10 / Don't consider "ix-dev" directory as a train

### DIFF
--- a/catalog_validation/git_utils.py
+++ b/catalog_validation/git_utils.py
@@ -1,6 +1,8 @@
 import os
 import subprocess
 
+from catalog_validation.items.utils import valid_train
+
 from .exceptions import CatalogDoesNotExist
 from .utils import CatalogItem
 
@@ -15,7 +17,8 @@ def get_affected_catalog_items_with_versions(catalog_path, base_branch='master')
     )
     items_to_be_checked = []
     for file_path in filter(bool, map(str.strip, cp.stdout.decode().split('\n'))):
-        if file_path.startswith(('.', 'library/', 'docs/')):
+        train_name = file_path.split('/', 1)[0]
+        if not valid_train(train_name, os.path.join(catalog_path, train_name)):
             continue
         # Any file not being under a version directory is of no use to us and we can skip it as it's not enough
         # for us to test the catalog item in question

--- a/catalog_validation/items/catalog.py
+++ b/catalog_validation/items/catalog.py
@@ -6,7 +6,7 @@ import typing
 from catalog_validation.utils import VALID_TRAIN_REGEX
 
 from .items_util import get_item_details, get_default_questions_context
-from .utils import TRAIN_IGNORE_DIRS
+from .utils import TRAIN_IGNORE_DIRS, valid_train
 
 
 def item_details(items: dict, location: str, questions_context: typing.Optional[dict], item_key: str) -> dict:
@@ -23,13 +23,7 @@ def retrieve_train_names(location: str, all_trains=True, trains_filter=None) -> 
     train_names = []
     trains_filter = trains_filter or []
     for train in os.listdir(location):
-        if (
-            not (all_trains or train in trains_filter) or not os.path.isdir(
-                os.path.join(location, train)
-            ) or train.startswith('.') or train in TRAIN_IGNORE_DIRS or not VALID_TRAIN_REGEX.match(
-                train
-            )
-        ):
+        if not (all_trains or train in trains_filter) or not valid_train(train, os.path.join(location, train)):
             continue
         train_names.append(train)
     return train_names

--- a/catalog_validation/items/catalog.py
+++ b/catalog_validation/items/catalog.py
@@ -3,10 +3,10 @@ import functools
 import os
 import typing
 
-from catalog_validation.schema.migration_schema import MIGRATION_DIRS
 from catalog_validation.utils import VALID_TRAIN_REGEX
 
 from .items_util import get_item_details, get_default_questions_context
+from .utils import TRAIN_IGNORE_DIRS
 
 
 def item_details(items: dict, location: str, questions_context: typing.Optional[dict], item_key: str) -> dict:
@@ -26,7 +26,7 @@ def retrieve_train_names(location: str, all_trains=True, trains_filter=None) -> 
         if (
             not (all_trains or train in trains_filter) or not os.path.isdir(
                 os.path.join(location, train)
-            ) or train.startswith('.') or train in ['library', 'docs'] + MIGRATION_DIRS or not VALID_TRAIN_REGEX.match(
+            ) or train.startswith('.') or train in TRAIN_IGNORE_DIRS or not VALID_TRAIN_REGEX.match(
                 train
             )
         ):

--- a/catalog_validation/items/catalog.py
+++ b/catalog_validation/items/catalog.py
@@ -3,10 +3,8 @@ import functools
 import os
 import typing
 
-from catalog_validation.utils import VALID_TRAIN_REGEX
-
 from .items_util import get_item_details, get_default_questions_context
-from .utils import TRAIN_IGNORE_DIRS, valid_train
+from .utils import valid_train
 
 
 def item_details(items: dict, location: str, questions_context: typing.Optional[dict], item_key: str) -> dict:

--- a/catalog_validation/items/utils.py
+++ b/catalog_validation/items/utils.py
@@ -1,10 +1,12 @@
 import contextlib
 import git
+import os
 
 from datetime import datetime
 from typing import Optional
 
 from catalog_validation.schema.migration_schema import MIGRATION_DIRS
+from catalog_validation.utils import VALID_TRAIN_REGEX
 
 
 TRAIN_IGNORE_DIRS = ['library', 'docs'] + MIGRATION_DIRS
@@ -86,3 +88,9 @@ def get_last_updated_date(repo_path: str, folder_path: str) -> Optional[str]:
             return timestamp.strftime('%Y-%m-%d %H:%M:%S')
         else:
             return None
+
+
+def valid_train(train_name: str, train_location: str) -> bool:
+    return VALID_TRAIN_REGEX.match(
+        train_name
+    ) and not train_name.startswith('.') and train_name not in TRAIN_IGNORE_DIRS and os.path.isdir(train_location)

--- a/catalog_validation/items/utils.py
+++ b/catalog_validation/items/utils.py
@@ -4,6 +4,11 @@ import git
 from datetime import datetime
 from typing import Optional
 
+from catalog_validation.schema.migration_schema import MIGRATION_DIRS
+
+
+TRAIN_IGNORE_DIRS = ['library', 'docs'] + MIGRATION_DIRS
+
 
 def get_catalog_json_schema() -> dict:
     return {

--- a/catalog_validation/items/utils.py
+++ b/catalog_validation/items/utils.py
@@ -9,7 +9,7 @@ from catalog_validation.schema.migration_schema import MIGRATION_DIRS
 from catalog_validation.utils import VALID_TRAIN_REGEX
 
 
-TRAIN_IGNORE_DIRS = ['library', 'docs'] + MIGRATION_DIRS
+TRAIN_IGNORE_DIRS = ['library', 'docs', 'ix-dev'] + MIGRATION_DIRS
 
 
 def get_catalog_json_schema() -> dict:

--- a/catalog_validation/validation.py
+++ b/catalog_validation/validation.py
@@ -12,7 +12,7 @@ from .items.ix_values_utils import validate_ix_values_schema
 from .items.questions_utils import (
     CUSTOM_PORTALS_KEY, CUSTOM_PORTALS_ENABLE_KEY, CUSTOM_PORTAL_GROUP_KEY,
 )
-from .items.utils import get_catalog_json_schema
+from .items.utils import get_catalog_json_schema, TRAIN_IGNORE_DIRS
 from .schema.migration_schema import APP_MIGRATION_SCHEMA, MIGRATION_DIRS, RE_MIGRATION_NAME, RE_MIGRATION_NAME_STR
 from .schema.variable import Variable
 from .utils import CACHED_CATALOG_FILE_NAME, validate_key_value_types, VALID_TRAIN_REGEX, WANTED_FILES_IN_ITEM_VERSION
@@ -47,7 +47,7 @@ def validate_catalog(catalog_path):
     for file_dir in os.listdir(catalog_path):
         complete_path = os.path.join(catalog_path, file_dir)
         if file_dir not in MIGRATION_DIRS and (
-            file_dir.startswith('.') or not os.path.isdir(complete_path) or file_dir in ('library', 'docs')
+            file_dir.startswith('.') or not os.path.isdir(complete_path) or file_dir in TRAIN_IGNORE_DIRS
         ):
             continue
         if file_dir in MIGRATION_DIRS:


### PR DESCRIPTION
This PR adds changes to not consider `ix-dev` directory as a train. Motivation behind the change is that under this directory we can have direct app directories without versions, this will help us retain git history for an app in question and we can copy paste the helm chart details to the stable train from here.