### PR TITLE
NAS-120252 / 23.10 / Allow specifying ACLs for apps

### DIFF
--- a/catalog_validation/items/questions_utils.py
+++ b/catalog_validation/items/questions_utils.py
@@ -1,6 +1,6 @@
 import itertools
 
-from .utils import ACL_QUESTION
+from .utils import ACL_QUESTION, IX_VOLUMES_ACL_QUESTION
 
 
 CUSTOM_PORTALS_KEY = 'iXPortals'
@@ -158,7 +158,7 @@ def normalise_question(question: dict, version_data: dict, context: dict) -> Non
                 # get index of aclEntries from attrs
                 acl_index = next(i for i, v in enumerate(schema['attrs']) if v['variable'] == 'aclEntries')
                 # insert acl question before aclEntries
-                schema['attrs'][acl_index]['schema']['attrs'] = ACL_QUESTION
+                schema['attrs'][acl_index]['schema']['attrs'] = IX_VOLUMES_ACL_QUESTION
 
     schema.update(data)
 

--- a/catalog_validation/items/questions_utils.py
+++ b/catalog_validation/items/questions_utils.py
@@ -1,5 +1,7 @@
 import itertools
 
+from .utils import ACL_QUESTION
+
 
 CUSTOM_PORTALS_KEY = 'iXPortals'
 CUSTOM_PORTALS_ENABLE_KEY = 'enableIXPortals'
@@ -149,6 +151,14 @@ def normalise_question(question: dict, version_data: dict, context: dict) -> Non
                 {'value': i['id'], 'description': f'{i["name"]!r} Certificate Authority'}
                 for i in context['certificate_authorities']
             ]
+        elif ref == 'normalize/acl':
+            data['attrs'] = ACL_QUESTION
+        elif ref == 'normalize/ixVolume':
+            if schema['type'] == 'dict' and any(i['variable'] == 'aclEntries' for i in schema['attrs']):
+                # get index of aclEntries from attrs
+                acl_index = next(i for i, v in enumerate(schema['attrs']) if v['variable'] == 'aclEntries')
+                # insert acl question before aclEntries
+                schema['attrs'][acl_index]['schema']['attrs'] = ACL_QUESTION
 
     schema.update(data)
 

--- a/catalog_validation/items/utils.py
+++ b/catalog_validation/items/utils.py
@@ -86,6 +86,19 @@ ACL_QUESTION = [
     }
 ]
 
+IX_VOLUMES_ACL_QUESTION = [
+    {
+        'variable': 'path',
+        'label': 'Path',
+        'description': 'Path to perform ACL',
+        'schema': {
+            'type': 'string',
+            'hidden': True
+        }
+    },
+    ACL_QUESTION[1]
+]
+
 
 def get_catalog_json_schema() -> dict:
     return {
@@ -122,7 +135,7 @@ def get_catalog_json_schema() -> dict:
                                 'type': ['string', 'null'],
                             },
                             'last_update': {
-                                'type': 'string',
+                                'type': ['string', 'null'],
                             },
                             'latest_version': {
                                 'type': 'string',

--- a/catalog_validation/items/utils.py
+++ b/catalog_validation/items/utils.py
@@ -23,6 +23,70 @@ RECOMMENDED_APPS_SCHEMA = {
 TRAIN_IGNORE_DIRS = ['library', 'docs', DEVELOPMENT_DIR] + MIGRATION_DIRS
 
 
+ACL_QUESTION = [
+    {
+        'variable': 'path',
+        'label': 'Path',
+        'description': 'Path to perform ACL',
+        'schema': {
+            'type': 'string',
+            'required': True,
+            'empty': False,
+        }
+    },
+    {
+        'variable': 'entries',
+        'label': 'ACL Entries',
+        'description': 'ACL Entries',
+        'schema': {
+            'type': 'list',
+            'items': [{
+                'variable': 'aclEntry',
+                'label': 'ACL Entry',
+                'schema': {
+                    'type': 'dict',
+                    'attrs': [
+                        {
+                            'variable': 'id_type',
+                            'label': 'ID Type',
+                            'schema': {
+                                'type': 'string',
+                                'enum': [
+                                    {'value': 'USER', 'description': 'Entry is for a USER'},
+                                    {'value': 'GROUP', 'description': 'Entry is for a GROUP'},
+                                ],
+                                'default': 'USER',
+                            }
+                        },
+                        {
+                            'variable': 'id',
+                            'label': 'ID',
+                            'schema': {
+                                'type': 'int',
+                                'required': True,
+                                'min': 0,
+                            }
+                        },
+                        {
+                            'variable': 'access',
+                            'label': 'Access',
+                            'schema': {
+                                'type': 'string',
+                                'enum': [
+                                    {'value': 'READ', 'description': 'Read Access'},
+                                    {'value': 'MODIFY', 'description': 'Modify Access'},
+                                    {'value': 'FULL_CONTROL', 'description': 'FULL_CONTROL Access'},
+                                ],
+                            }
+                        }
+                    ],
+                }
+            }]
+        }
+    }
+]
+
+
 def get_catalog_json_schema() -> dict:
     return {
         'type': 'object',

--- a/catalog_validation/schema/features.py
+++ b/catalog_validation/schema/features.py
@@ -1,6 +1,6 @@
 from catalog_validation.exceptions import ValidationErrors
 
-from .schema_gen import DictSchema, IntegerSchema, ListSchema, StringSchema
+from .schema_gen import DictSchema, IntegerSchema, StringSchema
 
 
 class Feature:
@@ -44,6 +44,9 @@ class IXVolumeFeature(Feature):
             verrors.add(f'{schema_str}.attrs', 'Variable "datasetName" must be specified.')
         elif not isinstance(attrs[attrs.index('datasetName')].schema, StringSchema):
             verrors.add(f'{schema_str}.attrs', 'Variable "datasetName" must be of string type.')
+
+        if 'aclEntries' in attrs and not isinstance(attrs[attrs.index('aclEntries')].schema, DictSchema):
+            verrors.add(f'{schema_str}.attrs', 'Variable "aclEntries" must be of dict type.')
 
         if 'properties' in attrs:
             index = attrs.index('properties')
@@ -135,27 +138,15 @@ class ContainerImageFeature(Feature):
                 verrors.add(f'{schema_str}.attrs', f'Variable {check_attr!r} must be of string type.')
 
 
-class DefinitionACLFeature(Feature):
+class ACLFeature(Feature):
 
-    NAME = 'definitions/acl'
+    NAME = 'normalize/acl'
     VALID_SCHEMAS = [DictSchema]
-
-    def _validate(self, verrors, schema_obj, schema_str):
-        attrs = schema_obj.attrs
-        for check_attr, attr_schema in (
-            ('path', StringSchema),
-            ('entries', ListSchema),
-            ('options', DictSchema),
-        ):
-            if check_attr not in attrs:
-                verrors.add(f'{schema_str}.attrs', f'Variable {check_attr!r} must be specified.')
-            elif not isinstance(attrs[attrs.index(check_attr)].schema, attr_schema):
-                verrors.add(f'{schema_str}.attrs', f'Variable {check_attr!r} must be of {attr_schema.__name__} type.')
 
 
 FEATURES = [
+    ACLFeature(),
     IXVolumeFeature(),
-    DefinitionACLFeature(),
     DefinitionInterfaceFeature(),
     DefinitionGPUConfigurationFeature(),
     DefinitionTimezoneFeature(),

--- a/catalog_validation/schema/features.py
+++ b/catalog_validation/schema/features.py
@@ -1,6 +1,6 @@
 from catalog_validation.exceptions import ValidationErrors
 
-from .schema_gen import DictSchema, IntegerSchema, StringSchema
+from .schema_gen import DictSchema, IntegerSchema, ListSchema, StringSchema
 
 
 class Feature:
@@ -135,8 +135,27 @@ class ContainerImageFeature(Feature):
                 verrors.add(f'{schema_str}.attrs', f'Variable {check_attr!r} must be of string type.')
 
 
+class DefinitionACLFeature(Feature):
+
+    NAME = 'definitions/acl'
+    VALID_SCHEMAS = [DictSchema]
+
+    def _validate(self, verrors, schema_obj, schema_str):
+        attrs = schema_obj.attrs
+        for check_attr, attr_schema in (
+            ('path', StringSchema),
+            ('entries', ListSchema),
+            ('options', DictSchema),
+        ):
+            if check_attr not in attrs:
+                verrors.add(f'{schema_str}.attrs', f'Variable {check_attr!r} must be specified.')
+            elif not isinstance(attrs[attrs.index(check_attr)].schema, attr_schema):
+                verrors.add(f'{schema_str}.attrs', f'Variable {check_attr!r} must be of {attr_schema.__name__} type.')
+
+
 FEATURES = [
     IXVolumeFeature(),
+    DefinitionACLFeature(),
     DefinitionInterfaceFeature(),
     DefinitionGPUConfigurationFeature(),
     DefinitionTimezoneFeature(),


### PR DESCRIPTION
## Context

`filesystem.add_to_acl` has been added to allow app devs to correctly specify ACLs for host paths. A feature `normalize/acl` has been added which app devs can specify to consume the new feature.