### PR TITLE
NAS-120646 / 23.10 / Allow app developer to add custom error message

### DIFF
--- a/catalog_validation/schema/attrs.py
+++ b/catalog_validation/schema/attrs.py
@@ -129,7 +129,7 @@ class StringSchema(Schema):
     DEFAULT_TYPE = 'string'
 
     def __init__(self, data):
-        self.min_length = self.max_length = self.enum = self.private = self.valid_chars = None
+        self.min_length = self.max_length = self.enum = self.private = self.valid_chars = self.valid_chars_error = None
         super().__init__(data=data)
 
     def json_schema(self):
@@ -146,6 +146,9 @@ class StringSchema(Schema):
             },
             'valid_chars': {
                 'type': 'string',
+            },
+            'valid_chars_error': {
+                'type': 'string'
             },
         })
         return schema


### PR DESCRIPTION
## Context

If app developer uses `valid_chars` attribute to validate a value specified by user, the error is vague i.e does not match pattern.
It does not help tell the user that he needs to follow this specific order to be able to correctly specify the value in question so now the dev can specify a custom error message which will better guide the user on what to input for a field which is being validated by `valid_chars`.