### PR TITLE
last_update can be null in the CI when format is being validated

### DIFF
--- a/catalog_validation/items/utils.py
+++ b/catalog_validation/items/utils.py
@@ -58,7 +58,7 @@ def get_catalog_json_schema() -> dict:
                                 'type': ['string', 'null'],
                             },
                             'last_update': {
-                                'type': 'string',
+                                'type': ['string', 'null'],
                             },
                             'latest_version': {
                                 'type': 'string',


### PR DESCRIPTION
## Problem

`last_update` defaults to being `null` and it will be that in the CI when CI is validating workflow in truenas/charts PRs.

## Solution

Mark the field as being nullable.