### PR TITLE
NAS-121419 / 23.10 / Properly validate $ref value

### DIFF
--- a/catalog_validation/schema/attrs.py
+++ b/catalog_validation/schema/attrs.py
@@ -48,6 +48,10 @@ class Schema:
 
         if '$ref' in self._schema_data:
             for index, ref in enumerate(self._schema_data['$ref']):
+                if not isinstance(ref, str):
+                    verrors.add(f'{schema}.$ref.{index}', 'Must be a string')
+                    continue
+
                 feature_obj = get_feature(ref)
                 if not feature_obj:
                     continue


### PR DESCRIPTION
## Problem

We were not validating the type of content specified under `$ref` which resulted to unintended behaviour as the expectation is that it should be a string.

## Solution

Properly validate that each entry under a `$ref` should be a string.