### PR TITLE
NAS-121724 / 23.10 / Fix json schema list attrs usages

### DIFF
--- a/catalog_validation/schema/attrs.py
+++ b/catalog_validation/schema/attrs.py
@@ -101,7 +101,7 @@ class Schema:
                 },
             },
             'required': ['type'],
-            'dependencies': {
+            'dependentRequired': {
                 'show_subquestions_if': ['subquestions']
             }
         }

--- a/catalog_validation/schema/migration_schema.py
+++ b/catalog_validation/schema/migration_schema.py
@@ -3,7 +3,7 @@ import re
 
 APP_MIGRATION_SCHEMA = {
     'type': 'array',
-    'items': [{
+    'items': {
         'type': 'object',
         'properties': {
             'app_name': {'type': 'string'},
@@ -34,7 +34,7 @@ APP_MIGRATION_SCHEMA = {
                 },
             },
         ],
-    }],
+    },
 }
 MIGRATION_DIRS = ['.migrations', 'ix-migrations']
 RE_MIGRATION_NAME_STR = r'^\d+\w+.json'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gitpython
-jsonschema==3.2.0
+jsonschema==4.10.3
 kubernetes
 markdown
 pyyaml


### PR DESCRIPTION
## Problem

Json schema validation was failing when we updated to bookworm with the problem being invalid newer json schema being specified for validation.

## Solution

For `array` type objects when `items` is specified as a list it is expected that each item in the value which is to be validated will be mapped with each entry specified in `items` list. If the values are more in either list validation fails..in our case we want all the items to be of type `string` and in that case `items` should not be a list but rather the type we want all of the items to be enforced in the actual value of list (ref: https://json-schema.org/understanding-json-schema/reference/array.html)