### PR TITLE
NAS-121725 / 23.10 / Fix failed test in test-utils

### DIFF
--- a/catalog_validation/pytest/unit/test_items_util.py
+++ b/catalog_validation/pytest/unit/test_items_util.py
@@ -87,7 +87,7 @@ def test_get_item_details_impl(
     open_file_data = mocker.mock_open(read_data=open_yaml)
     mocker.patch('builtins.open', open_file_data)
     mocker.patch('os.path.isdir', return_value=True)
-    mocker.patch('os.listdir', return_value=['upgrade_info.json', '1.3.37', 'upgrade_strategy', 'item.yaml'])
+    mocker.patch('os.listdir', return_value=['1.3.37'])
     mocker.patch('catalog_validation.items.items_util.validate_item_version', return_value=None)
     mocker.patch('catalog_validation.items.items_util.get_item_version_details', return_value={})
     assert get_item_details_impl(item_path, schema, QUESTION_CONTEXT, options) == item_data_impl


### PR DESCRIPTION
## Context

After installing all packages in book worm this test was still failing because of the following reasons
1. `os.path.isdir` is mocked to true in all cases
2. `os.listdir` is mocked to the following list `['upgrade_info.json', '1.3.37', 'upgrade_strategy', 'item.yaml']` when `get_item_details_impl` func is run and it consider upgrade_info, upgrade_strategy, item.yaml as a folder and tries to parse its version which gives values error from that package. That ultimately leads to test failure
following is the code that emit the error.