### PR TITLE
Use bookworm in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 
 RUN apt-get update
 


### PR DESCRIPTION
## Context

We have shifted to `bookworm` and now should be using that instead of `bullseye` tag.