### PR TITLE
Enforce last_update field cannot be null

### DIFF
--- a/catalog_validation/items/utils.py
+++ b/catalog_validation/items/utils.py
@@ -135,7 +135,8 @@ def get_catalog_json_schema() -> dict:
                                 'type': ['string', 'null'],
                             },
                             'last_update': {
-                                'type': ['string', 'null'],
+                                'type': 'string',
+                                'pattern': r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$',
                             },
                             'latest_version': {
                                 'type': 'string',


### PR DESCRIPTION
## Problem

Right now `last_update` field can be null which should not be possible because `catalog.json` is generated from a github action we distribute and that should properly ensure `last_update` field generation. This field is also used to sort latest apps in middleware/UI so we need to enforce that it cannot be null and mark the catalog as UNHEALTHY if that is the case.

## Solution

Changes have been added to not allow `last_update` to be null and while at it also ensured that it conforms to the datetime pattern we use for converting the field to a datetime object i.e `%Y-%m-%d %H:%M:%S`