### PR TITLE
NAS-121986 / 23.10 / Specify screenshots in item.yaml

### DIFF
--- a/catalog_validation/items/items_util.py
+++ b/catalog_validation/items/items_util.py
@@ -101,8 +101,6 @@ def get_item_details(
                 item_data['home'] = chart_metadata['home']
             if not item_data['sources'] and chart_metadata.get('sources'):
                 item_data['sources'] = chart_metadata['sources']
-            if not item_data['screenshots'] and chart_metadata.get('annotations', {}).get('screenshots'):
-                item_data['screenshots'] = chart_metadata['annotations']['screenshots']
 
     if unhealthy_versions:
         item_data['healthy_error'] = f'Errors were found with {", ".join(unhealthy_versions)} version(s)'
@@ -123,6 +121,7 @@ def get_item_details_impl(
     item_data = {
         'categories': [],
         'icon_url': None,
+        'screenshots': [],
         'tags': [],
         'versions': {},
     }

--- a/catalog_validation/pytest/unit/test_items_util.py
+++ b/catalog_validation/pytest/unit/test_items_util.py
@@ -78,9 +78,12 @@ def test_get_item_details(mocker, item_location, options, items_data):
             'categories': ['storage', 'crypto'],
             'icon_url': 'https://www.chia.net/wp-content/uploads/2022/09/chia-logo.svg',
             'tags': ['finance'],
+            'screenshots': ['https://www.chia.net/wp-content/uploads/2022/09/chia-logo.svg'],
             'sources': ['https://hub.docker.com/r/emby/embyserver'],
         },
         '''
+        screenshots:
+          - 'https://www.chia.net/wp-content/uploads/2022/09/chia-logo.svg'
         tags:
           - finance
         categories:

--- a/catalog_validation/validation.py
+++ b/catalog_validation/validation.py
@@ -184,7 +184,9 @@ def validate_catalog_item(catalog_item_path, schema, validate_versions=True):
             item_config = yaml.safe_load(f.read())
 
         validate_key_value_types(
-            item_config, (('categories', list), ('tags', list, False)), verrors, f'{schema}.item_config'
+            item_config, (
+                ('categories', list), ('tags', list, False), ('screenshots', list, False),
+            ), verrors, f'{schema}.item_config'
         )
 
     for version_path in (versions if validate_versions else []):

--- a/catalog_validation/validation_utils.py
+++ b/catalog_validation/validation_utils.py
@@ -25,16 +25,6 @@ def validate_chart_version(
 
                     if not isinstance(chart_config.get('annotations', {}), dict):
                         verrors.add(f'{schema}.annotations', 'Annotations must be a dictionary')
-                    else:
-                        annotations = chart_config.get('annotations', {})
-                        if not isinstance(annotations.get('screenshots', []), list):
-                            verrors.add(f'{schema}.annotations.screenshots', 'Screenshots must be a list')
-                        else:
-                            for index, screenshot in enumerate(annotations.get('screenshots', [])):
-                                if not isinstance(screenshot, str):
-                                    verrors.add(
-                                        f'{schema}.annotations.screenshots.{index}', 'Screenshot must be a string'
-                                    )
 
                     if not isinstance(chart_config.get('sources', []), list):
                         verrors.add(f'{schema}.sources', 'Sources must be a list')


### PR DESCRIPTION
## Problem

Helm does not like having a list of strings under a string key in `annotations` in `Chart.yaml`.

## Solution

It seems best that we have screenshots defined in `item.yaml` instead of `Chart.yaml` as that is not taken into account by helm.