### PR TITLE
NAS-122209 / 23.10 / Add app migration file executable validation

### DIFF
--- a/catalog_validation/schema/migration_schema.py
+++ b/catalog_validation/schema/migration_schema.py
@@ -1,6 +1,7 @@
 import re
 
 
+APP_MIGRATION_DIR = 'migrations'
 APP_MIGRATION_SCHEMA = {
     'type': 'array',
     'items': {


### PR DESCRIPTION
## Problem
The catalog_validate app does not support validation of app migrations. It is crucial for these migration files to be executable, as failing to execute them can result in migrations being missed without the developer being notified in a timely manner.

## Solution
To address this problem,  add validation for app migration files and ensuring that these files are executable. By performing this validation, app developers can be alerted if any migration files are not executable, enabling them to take necessary actions to ensure the execution of these migrations.