### PR TITLE
Separate publish/update catalog actions

### DIFF
--- a/catalog_validation/scripts/catalog_update.py
+++ b/catalog_validation/scripts/catalog_update.py
@@ -114,21 +114,21 @@ def update_catalog_file(location: str) -> None:
     print(f'[\033[92mOK\x1B[0m]\tUpdated {catalog_file_path!r} successfully!')
 
 
-def update_catalog(catalog_path: str) -> None:
-    publish_updated_apps(catalog_path)
-    update_catalog_file(catalog_path)
-
-
 def main():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(help='sub-command help', dest='action')
+
+    publish_setup = subparsers.add_parser('publish', help='Publish apps of TrueNAS catalog')
+    publish_setup.add_argument('--path', help='Specify path of TrueNAS catalog')
 
     parser_setup = subparsers.add_parser('update', help='Update TrueNAS catalog')
     parser_setup.add_argument('--path', help='Specify path of TrueNAS catalog')
 
     args = parser.parse_args()
-    if args.action == 'update':
-        update_catalog(args.path)
+    if args.action == 'publish':
+        publish_updated_apps(args.path)
+    elif args.action == 'update':
+        update_catalog_file(args.path)
     else:
         parser.print_help()
 


### PR DESCRIPTION
## Problem

When new apps are published with github charts action - what happens is that code paths are created for new apps and those new apps are not tracked by git yet because a commit has not happened yet which happens in `last_update` field coming up as `null`.

## Solution

Publishing new apps should be a 2 step solution:
1. Publish the apps from development directory to their expected paths
2. Commit the changes using github action
3. Update catalog.json so that now it correctly reflects the `last_update` attr
4. Commit the modified catalog.json