### PR TITLE
NAS-122338 / 23.10 / Add unused ports to questions if specified by question

### DIFF
--- a/catalog_validation/items/items_util.py
+++ b/catalog_validation/items/items_util.py
@@ -210,4 +210,5 @@ def get_default_questions_context() -> dict:
         'certificates': [],
         'certificate_authorities': [],
         'system.general.config': {'timezone': 'America/Los_Angeles'},
+        'unused_ports': [i for i in range(1025, 65535)],
     }

--- a/catalog_validation/items/questions_utils.py
+++ b/catalog_validation/items/questions_utils.py
@@ -151,6 +151,15 @@ def normalise_question(question: dict, version_data: dict, context: dict) -> Non
                 {'value': i['id'], 'description': f'{i["name"]!r} Certificate Authority'}
                 for i in context['certificate_authorities']
             ]
+        elif ref == 'definitions/port':
+            data['enum'] = [{'value': None, 'description': 'No Port Selected'}] if schema.get('null') else []
+            data['enum'] += [
+                {'value': i, 'description': f'{i!r} Port'}
+                for i in filter(
+                    lambda p: schema.get('min', 9000) <= p <= schema.get('max', 65534),
+                    context['unused_ports']
+                )
+            ]
         elif ref == 'normalize/acl':
             data['attrs'] = ACL_QUESTION
         elif ref == 'normalize/ixVolume':


### PR DESCRIPTION
## Context

A `ref` is being added so questions in an app which consume ports and allow it to be user configurable have a way to show unused ports which can actually be used by the app.