### PR TITLE
NAS-122715 / 23.10 / Allow validating path is dir/file on host in apps

### DIFF
--- a/catalog_validation/schema/attrs.py
+++ b/catalog_validation/schema/attrs.py
@@ -186,6 +186,14 @@ class HostPathSchema(Schema):
     DEFAULT_TYPE = 'string'
 
 
+class HostPathDirSchema(Schema):
+    DEFAULT_TYPE = 'string'
+
+
+class HostPathFileSchema(Schema):
+    DEFAULT_TYPE = 'string'
+
+
 class URISchema(Schema):
     DEFAULT_TYPE = 'string'
 

--- a/catalog_validation/schema/schema_gen.py
+++ b/catalog_validation/schema/schema_gen.py
@@ -1,6 +1,6 @@
 from .attrs import (
-    BooleanSchema, StringSchema, IntegerSchema, PathSchema, HostPathSchema, ListSchema, DictSchema,
-    IPAddrSchema, CronSchema, URISchema
+    BooleanSchema, StringSchema, IntegerSchema, PathSchema, HostPathSchema, HostPathDirSchema,
+    HostPathFileSchema, ListSchema, DictSchema, IPAddrSchema, CronSchema, URISchema
 )
 
 
@@ -20,6 +20,10 @@ def get_schema(schema_data):
         schema = PathSchema
     elif s_type == 'hostpath':
         schema = HostPathSchema
+    elif s_type == 'hostpathdirectory':
+        schema = HostPathDirSchema
+    elif s_type == 'hostpathfile':
+        schema = HostPathFileSchema
     elif s_type == 'list':
         schema = ListSchema
     elif s_type == 'dict':


### PR DESCRIPTION
## Context

Expose `hostpathdirectory` and `hostpathfile` schemas to app developers so that they can consume it to validate if the host path being specified is a directory/file and have more validation in place to properly validate their app's values to conform to what's actually required by the app.