### PR TITLE
NAS-124275 / 24.04 / Skip version bump validation for upgrade strategy files

### DIFF
--- a/catalog_validation/git_utils.py
+++ b/catalog_validation/git_utils.py
@@ -28,6 +28,10 @@ def get_changed_apps(catalog_path: str, base_branch: str = 'master') -> dict:
             continue
 
         app_name = dev_dir_relative_path.split('/')[1]
+        base_name = os.path.basename(file_path)
+
+        if base_name in ['upgrade_strategy', 'upgrade_info']:
+            continue
         if not os.path.isdir(os.path.join(dev_directory_path, train_name, app_name)):
             continue
 

--- a/catalog_validation/validation.py
+++ b/catalog_validation/validation.py
@@ -327,7 +327,7 @@ def validate_questions_yaml(questions_yaml_path, schema):
 
     groups = []
     for index, group in enumerate(questions_config['groups']):
-        if type(group) != dict:
+        if not isinstance(group, dict):
             verrors.add(f'{schema}.groups.{index}', 'Type of group should be a dictionary.')
             continue
 
@@ -393,7 +393,7 @@ def validate_variable_uniqueness(data, schema, verrors):
 
 
 def validate_question(question_data, schema, verrors, validate_top_level_attrs=None):
-    if type(question_data) != dict:
+    if not isinstance(question_data, dict):
         verrors.add(schema, 'Question must be a valid dictionary.')
         return
 


### PR DESCRIPTION
### Problem

CI was failing with bump version error even when the only file changed was **upgrade_strategy**

### Fix

The condition is added so that if only **upgrade_strategy** or **upgrade_info** file is changed CI will not fail with the above mentioned error.