### PR TITLE
NAS-124094 / 24.04 / Add to keep version file to preserve some app versions

### DIFF
--- a/catalog_validation/ci/utils.py
+++ b/catalog_validation/ci/utils.py
@@ -2,12 +2,23 @@ import os
 import yaml
 
 from catalog_validation.items.utils import DEVELOPMENT_DIR
+from jsonschema import validate as json_schema_validate
 from semantic_version import Version
 
 
 DEV_DIRECTORY_RELATIVE_PATH: str = os.path.join('library', DEVELOPMENT_DIR)
-OPTIONAL_METADATA_FILES = ['upgrade_info.json', 'upgrade_strategy']
+TO_KEEP_VERSIONS = 'to_keep_versions.yaml'
+OPTIONAL_METADATA_FILES = ['upgrade_info.json', 'upgrade_strategy', TO_KEEP_VERSIONS]
 REQUIRED_METADATA_FILES = ['item.yaml']
+
+
+REQUIRED_VERSIONS_SCHEMA = {
+    'type': 'array',
+    'items': {
+        'type': 'string',
+        'pattern': '[0-9]+.[0-9]+.[0-9]+'
+    }
+}
 
 
 def get_app_version(app_path: str) -> str:
@@ -18,6 +29,17 @@ def get_app_version(app_path: str) -> str:
 
 def get_ci_development_directory(catalog_path: str) -> str:
     return os.path.join(catalog_path, DEV_DIRECTORY_RELATIVE_PATH)
+
+
+def get_to_keep_versions(app_dir_path: str) -> list:
+    required_version_path = os.path.join(app_dir_path, TO_KEEP_VERSIONS)
+    if not os.path.exists(required_version_path):
+        return []
+
+    with open(required_version_path, 'r') as f:
+        data = yaml.safe_load(f.read())
+        json_schema_validate(data, REQUIRED_VERSIONS_SCHEMA)
+    return data
 
 
 def version_has_been_bumped(app_path: str, new_version: str) -> bool:

--- a/catalog_validation/scripts/catalog_update.py
+++ b/catalog_validation/scripts/catalog_update.py
@@ -9,7 +9,7 @@ from jsonschema import validate as json_schema_validate, ValidationError as Json
 
 from catalog_validation.ci.utils import (
     get_app_version, get_ci_development_directory, OPTIONAL_METADATA_FILES,
-    REQUIRED_METADATA_FILES, version_has_been_bumped,
+    REQUIRED_METADATA_FILES, version_has_been_bumped, get_to_keep_versions
 )
 from catalog_validation.exceptions import ValidationErrors
 from catalog_validation.items.catalog import get_items_in_trains, retrieve_train_names, retrieve_trains_data
@@ -74,6 +74,7 @@ def publish_updated_apps(catalog_path: str) -> None:
             dev_app_path = os.path.join(dev_train_path, app_name)
             publish_app_path = os.path.join(publish_train_path, app_name)
             publish_app_version_path = os.path.join(publish_app_path, app_version)
+            required_versions = get_to_keep_versions(dev_app_path)
             os.makedirs(publish_app_path, exist_ok=True)
 
             dev_item_yaml_path = os.path.join(dev_app_path, 'item.yaml')
@@ -92,7 +93,7 @@ def publish_updated_apps(catalog_path: str) -> None:
 
             for version in os.listdir(publish_app_path):
                 version_path = os.path.join(publish_app_path, version)
-                if not os.path.isdir(version_path):
+                if not os.path.isdir(version_path) or version in required_versions:
                     continue
 
                 if version != app_version:


### PR DESCRIPTION
## Problem
In the current Continuous Integration (CI) process, all versions of apps are being removed except for the last/latest version. However, in certain cases, it is necessary to keep previous app versions, such as for upgrading between major versions (e.g., Nextcloud, which doesn't allow direct multiple major version jumps).

## Solution
To address this issue, a new feature has been introduced in the app CI pipeline. App developers are required to specify a list of versions that they wish to preserve in a `to_keep_versions.yaml` file, which should be placed within the `ix-dev` apps folder. The CI process will then refrain from deleting the versions that have been defined in this file.

For example:

```yaml
- 1.0.3
- 1.0.33
```

This change allows developers to retain specific app versions as needed for various purposes, such as ensuring smoother major version upgrades.