### PR TITLE
NAS-124604 / 24.04 / Make sure versions are properly reflected

### DIFF
--- a/catalog_validation/ci/utils.py
+++ b/catalog_validation/ci/utils.py
@@ -49,4 +49,5 @@ def version_has_been_bumped(app_path: str, new_version: str) -> bool:
     versions = [
         Version(version) for version in filter(lambda v: os.path.isdir(os.path.join(app_path, v)), os.listdir(app_path))
     ]
+    versions.sort()
     return not versions or Version(new_version) > versions[-1]

--- a/catalog_validation/git_utils.py
+++ b/catalog_validation/git_utils.py
@@ -5,6 +5,7 @@ from catalog_validation.ci.utils import DEV_DIRECTORY_RELATIVE_PATH, get_ci_deve
 from catalog_validation.items.utils import valid_train
 from collections import defaultdict
 
+from .ci.utils import OPTIONAL_METADATA_FILES
 from .exceptions import CatalogDoesNotExist
 
 
@@ -30,7 +31,7 @@ def get_changed_apps(catalog_path: str, base_branch: str = 'master') -> dict:
         app_name = dev_dir_relative_path.split('/')[1]
         base_name = os.path.basename(file_path)
 
-        if base_name in ['upgrade_strategy', 'upgrade_info']:
+        if base_name in OPTIONAL_METADATA_FILES:
             continue
         if not os.path.isdir(os.path.join(dev_directory_path, train_name, app_name)):
             continue


### PR DESCRIPTION
## Problem
The issue arises from `catalog_update` publishing apps that have only been updated in the `to_keep_versions.yaml` file without bumping their versions. These apps already exist in the catalog because the versions specified in this file are not being deleted by `catalog_update`, resulting in this problem. The problem is exacerbated when validating version bumps for apps with multiple versions. It can mistakenly pick a lower version of an app that hasn't been deleted and compare it to the current version. Changes in the `to_keep_versions.yaml` file trigger `catalog_update`, even though version bumps have not occurred.

## Solution
To address this issue, the solution involves sorting the versions list to ensure the latest version is considered during version bump validation. Additionally, changes are implemented to ignore any app from being published if the only changes are in the `to_keep_versions.yaml` file. Version bumps will not be required in this scenario.