### PR TITLE
NAS-124625 / 24.04 / Add update strategy validation

### DIFF
--- a/catalog_validation/ci/utils.py
+++ b/catalog_validation/ci/utils.py
@@ -10,6 +10,7 @@ DEV_DIRECTORY_RELATIVE_PATH: str = os.path.join('library', DEVELOPMENT_DIR)
 TO_KEEP_VERSIONS = 'to_keep_versions.yaml'
 OPTIONAL_METADATA_FILES = ['upgrade_info.json', 'upgrade_strategy', TO_KEEP_VERSIONS]
 REQUIRED_METADATA_FILES = ['item.yaml']
+UPDATE_STRATEGY_FILE = 'upgrade_strategy'
 
 
 REQUIRED_VERSIONS_SCHEMA = {

--- a/catalog_validation/ci/validate.py
+++ b/catalog_validation/ci/validate.py
@@ -7,7 +7,7 @@ from jsonschema import ValidationError as JsonValidationError
 
 from .utils import (
     get_app_version, get_ci_development_directory, REQUIRED_METADATA_FILES, version_has_been_bumped,
-    TO_KEEP_VERSIONS, REQUIRED_VERSIONS_SCHEMA, get_to_keep_versions,
+    TO_KEEP_VERSIONS, REQUIRED_VERSIONS_SCHEMA, get_to_keep_versions, UPDATE_STRATEGY_FILE
 )
 
 
@@ -67,7 +67,11 @@ def validate_keep_versions(app_dir_path: str, schema: str, verrors: ValidationEr
             f'Invalid json schema {TO_KEEP_VERSIONS} must contain list of required versions'
         )
 
-    return verrors
+
+def validate_upgrate_strategy(app_path, schema, verrors):
+    upgrade_strategy_path = os.path.join(app_path, UPDATE_STRATEGY_FILE)
+    if os.path.exists(upgrade_strategy_path) and not os.access(upgrade_strategy_path, os.X_OK):
+        verrors.add(schema, f'{upgrade_strategy_path!r} is not executable')
 
 
 def validate_app(app_dir_path: str, schema: str) -> None:
@@ -88,5 +92,5 @@ def validate_app(app_dir_path: str, schema: str) -> None:
             f'{schema}.required_files',
             f'{", ".join(missing_files)!r} file(s) must be specified'
         )
-
+    validate_upgrate_strategy(app_dir_path, f'{schema}.{UPDATE_STRATEGY_FILE}', verrors)
     verrors.check()


### PR DESCRIPTION
## Problem
During the upgrade process, certain upgrade strategies in the `charts` repository are found to be non-executable. This issue results in the failure of app upgrades.

## Solution
To address this problem, validations have been added to prevent the execution of non-executable upgrade strategies.
The added validations ensure that only executable upgrade strategies are used during the app upgrade process, thereby preventing failures and ensuring a smooth upgrade experience.