### PR TITLE
NAS-125107 / 24.04 / Add a description for the user/group id

### DIFF
--- a/catalog_validation/items/utils.py
+++ b/catalog_validation/items/utils.py
@@ -61,6 +61,8 @@ ACL_QUESTION = [
                         {
                             'variable': 'id',
                             'label': 'ID',
+                            'description': 'Make sure to check the ID value is correct and aligns with '
+                                           'RunAs user context of the application',
                             'schema': {
                                 'type': 'int',
                                 'required': True,


### PR DESCRIPTION
This commit adds changes to add a description for user/group id so user knows that he should apply ACLs keeping in line with the run as user context of the app because if misconfigured ACLs were applied the app might not work properly.