### PR TITLE
NAS-125386 / 24.04 / Fix validation for charts migration file to be executable

### DIFF
--- a/catalog_validation/pytest/unit/test_catalog_validate.py
+++ b/catalog_validation/pytest/unit/test_catalog_validate.py
@@ -226,6 +226,7 @@ def test_validate_catalog_item_version(mocker, chart_yaml, should_work):
     mocker.patch('builtins.open', open_file)
     mocker.patch('catalog_validation.validation.validate_questions_yaml', return_value=None)
     mocker.patch('catalog_validation.validation.validate_ix_values_yaml', return_value=None)
+    mocker.patch('catalog_validation.validation.validate_app_migrations', return_value=None)
     if should_work:
         assert validate_catalog_item_version(
             '/mnt/mypool/ix-applications/catalogs/github_com_truenas_charts_git_master/charts/storj/1.0.4',

--- a/catalog_validation/validation.py
+++ b/catalog_validation/validation.py
@@ -212,8 +212,7 @@ def validate_catalog_item(catalog_item_path, schema, validate_versions=True):
     verrors.check()
 
 
-def validate_app_migrations(version_path, schema):
-    verrors = ValidationErrors()
+def validate_app_migrations(verrors, version_path, schema):
     app_migration_path = os.path.join(version_path, APP_MIGRATION_DIR)
 
     if not os.path.exists(app_migration_path):
@@ -277,7 +276,7 @@ def validate_catalog_item_version(
         except ValidationErrors as v:
             verrors.extend(v)
 
-    validate_app_migrations(version_path, f'{schema}.app_migrations')
+    validate_app_migrations(verrors, version_path, f'{schema}.app_migrations')
 
     verrors.check()
 


### PR DESCRIPTION
### Context

Verrors being initialized in `validate_app_migrations` and not checked was causing a problem in raising errors on chart migration files' non-executable issue.

PR fixes the problem by sending verrors in params of `validate_app_migrations`.