### PR TITLE
NAS-125106 / 24.04 / Add user-selectable force option in ACL entries

### DIFF
--- a/catalog_validation/items/utils.py
+++ b/catalog_validation/items/utils.py
@@ -85,7 +85,25 @@ ACL_QUESTION = [
                 }
             }]
         }
-    }
+    },
+    {
+        'variable': 'options',
+        'label': 'ACL Options',
+        'schema': {
+            'type': 'dict',
+            'attrs': [
+                {
+                    'variable': 'force',
+                    'label': 'Force Flag',
+                    'description': 'Enabling `Force` applies ACL even if the path has existing data',
+                    'schema': {
+                        'type': 'boolean',
+                        'default': False,
+                    }
+                },
+            ],
+        },
+    },
 ]
 
 IX_VOLUMES_ACL_QUESTION = [


### PR DESCRIPTION
### Context

Applying ACL for a non-empty path required `force flag` to be `true` which was `false` by default and not user configurable.

### Change

This PR adds the option for the user to configure `force flag` as desired during chart create or update process.