### PR TITLE
NAS-125528 / 23.10.1 / Backport ACL flag changes (by Qubad786)

### DIFF
--- a/catalog_validation/items/utils.py
+++ b/catalog_validation/items/utils.py
@@ -26,10 +26,10 @@ TRAIN_IGNORE_DIRS = ['library', 'docs', DEVELOPMENT_DIR] + MIGRATION_DIRS
 ACL_QUESTION = [
     {
         'variable': 'path',
-        'label': 'Path',
-        'description': 'Path to perform ACL',
+        'label': 'Host Path',
+        'description': 'Host Path to perform ACL',
         'schema': {
-            'type': 'string',
+            'type': 'hostpath',
             'required': True,
             'empty': False,
         }
@@ -61,6 +61,8 @@ ACL_QUESTION = [
                         {
                             'variable': 'id',
                             'label': 'ID',
+                            'description': 'Make sure to check the ID value is correct and aligns with '
+                                           'RunAs user context of the application',
                             'schema': {
                                 'type': 'int',
                                 'required': True,
@@ -83,7 +85,25 @@ ACL_QUESTION = [
                 }
             }]
         }
-    }
+    },
+    {
+        'variable': 'options',
+        'label': 'ACL Options',
+        'schema': {
+            'type': 'dict',
+            'attrs': [
+                {
+                    'variable': 'force',
+                    'label': 'Force Flag',
+                    'description': 'Enabling `Force` applies ACL even if the path has existing data',
+                    'schema': {
+                        'type': 'boolean',
+                        'default': False,
+                    }
+                },
+            ],
+        },
+    },
 ]
 
 IX_VOLUMES_ACL_QUESTION = [


### PR DESCRIPTION
## Context

It was requested by Stavros that we backport ACL changes so users can make use of the new force flag properly.

Following changes have been backported:

1. Change type from `string` to `hostpath`
2. Change label
3. Add help text for ID
4. Add `force flag` option for user to add ACL for non-empty paths

Original PR: https://github.com/truenas/catalog_validation/pull/85
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125528