### PR TITLE
Add a text field schema for UI

### DIFF
--- a/catalog_validation/schema/attrs.py
+++ b/catalog_validation/schema/attrs.py
@@ -158,6 +158,22 @@ class StringSchema(Schema):
         return schema
 
 
+class TextFieldSchema(StringSchema):
+    def __init__(self, data):
+        super().__init__(data)
+        self.max_length = 1024 * 1024
+
+    def json_schema(self):
+        schema = super().json_schema()
+        schema['properties'].update({
+            'max_length': {
+                'type': 'integer',
+                'const': 1024 * 1024
+            }
+        })
+        return schema
+
+
 class IntegerSchema(Schema):
     DEFAULT_TYPE = 'integer'
 

--- a/catalog_validation/schema/schema_gen.py
+++ b/catalog_validation/schema/schema_gen.py
@@ -1,5 +1,5 @@
 from .attrs import (
-    BooleanSchema, StringSchema, IntegerSchema, PathSchema, HostPathSchema, HostPathDirSchema,
+    BooleanSchema, StringSchema, TextFieldSchema, IntegerSchema, PathSchema, HostPathSchema, HostPathDirSchema,
     HostPathFileSchema, ListSchema, DictSchema, IPAddrSchema, CronSchema, URISchema
 )
 
@@ -14,6 +14,8 @@ def get_schema(schema_data):
         schema = BooleanSchema
     elif s_type == 'string':
         schema = StringSchema
+    elif s_type == 'text':
+        schema = TextFieldSchema
     elif s_type == 'int':
         schema = IntegerSchema
     elif s_type == 'path':


### PR DESCRIPTION
## Context

PR adds new Text Class which can take string / text data of upto 1 MiB. Motivation is to allow UI to make a distinction that this is not a regular string field and UI can adjust size of the field accordingly then in the UI.

After discussing with Stavros - this field will be useful to specify data for configmaps which we might want to go as is like configurations etc.

(Jira issue: https://ixsystems.atlassian.net/browse/TNCHARTS-443 not sure how the bug clerk integration works for tncharts issues)