### PR TITLE
NAS-127699 / 24.04 / Add validation for language type of text field schema

### DIFF
--- a/catalog_validation/schema/attrs.py
+++ b/catalog_validation/schema/attrs.py
@@ -169,6 +169,10 @@ class TextFieldSchema(StringSchema):
             'max_length': {
                 'type': 'integer',
                 'const': 1024 * 1024
+            },
+            'language': {
+                'type': 'string',
+                'enum': ['yaml', 'json', 'toml', 'text'],
             }
         })
         return schema


### PR DESCRIPTION
### Context

UI needed a language type for text field in order to load language specific syntax highlighter

### Change

PR adds the validation to check that language type specified by app developer is either YAML, JSON, TOML, or plain text. Schema for text type variable can be something like: 
```
    "variable": "testtext",
    "label": "Test Text Field",
    "group": "Plex Configuration",
    "description": "This is to test text schema",
    "schema": {
         "type": "text",
         "language": "yaml",
         "default": ""
   }